### PR TITLE
feat: add user profile menu

### DIFF
--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -6,6 +6,7 @@ function App() {
   const [pmtde, setPmtde] = React.useState([]);
   const [programasGuardarrail, setProgramasGuardarrail] = React.useState([]);
   const [drawerOpen, setDrawerOpen] = React.useState(false);
+  const [profileAnchor, setProfileAnchor] = React.useState(null);
 
   const go = (v) => {
     setView(v);
@@ -29,9 +30,27 @@ function App() {
           <Typography variant="h6" sx={{ flexGrow: 1 }}>
             PMTDE
           </Typography>
-          <IconButton color="inherit" onClick={() => setView('admin')}>
-            <span className="material-symbols-outlined">settings</span>
-          </IconButton>
+          <Tooltip title="Administración">
+            <IconButton color="inherit" onClick={() => setView('admin')}>
+              <span className="material-symbols-outlined">settings</span>
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Perfil de usuario">
+            <IconButton
+              color="inherit"
+              onClick={(e) => setProfileAnchor(e.currentTarget)}
+            >
+              <span className="material-symbols-outlined">account_circle</span>
+            </IconButton>
+          </Tooltip>
+          <Menu
+            anchorEl={profileAnchor}
+            open={Boolean(profileAnchor)}
+            onClose={() => setProfileAnchor(null)}
+          >
+            <MenuItem onClick={() => setProfileAnchor(null)}>Perfil</MenuItem>
+            <MenuItem onClick={() => setProfileAnchor(null)}>Cerrar sesión</MenuItem>
+          </Menu>
         </Toolbar>
       </AppBar>
 

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -27,7 +27,9 @@ const {
   ListItemButton,
   ListItemIcon,
   ListItemText,
-  ListItem
+  ListItem,
+  Menu,
+  MenuItem
 } = MaterialUI;
 
 const formatDate = () => {


### PR DESCRIPTION
## Summary
- add user profile menu to header
- expose Menu components for profile actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a231c3a2048331a722ea175d4b10a4