### PR TITLE
Persist user entity in dedicated table

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -13,6 +13,29 @@ async function initDb() {
   await pool.query(
     'CREATE TABLE IF NOT EXISTS entities (id INT AUTO_INCREMENT PRIMARY KEY, entity VARCHAR(255) NOT NULL, data JSON NOT NULL)'
   );
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS usuarios (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      nombre VARCHAR(255) NOT NULL DEFAULT 'n/a',
+      apellidos VARCHAR(255) NOT NULL DEFAULT 'n/a',
+      email VARCHAR(255) NOT NULL DEFAULT 'n/a'
+    )`
+  );
+
+  const [oldUsers] = await pool.query(
+    'SELECT id, data FROM entities WHERE entity="usuarios"'
+  );
+  for (const row of oldUsers) {
+    const data = row.data || {};
+    const nombre = data.nombre || 'n/a';
+    const apellidos = data.apellidos || 'n/a';
+    const email = data.email || 'n/a';
+    await pool.query(
+      'INSERT INTO usuarios (id, nombre, apellidos, email) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE nombre=VALUES(nombre), apellidos=VALUES(apellidos), email=VALUES(email)',
+      [row.id, nombre, apellidos, email]
+    );
+    await pool.query('DELETE FROM entities WHERE id=?', [row.id]);
+  }
 }
 
 function getDb() {

--- a/backend/routes/usuarios.js
+++ b/backend/routes/usuarios.js
@@ -2,40 +2,36 @@ const express = require('express');
 const { getDb } = require('../db');
 
 const router = express.Router();
-const entity = 'usuarios';
 
 router.get('/', async (req, res) => {
   const pool = getDb();
-  const [rows] = await pool.query('SELECT id, data FROM entities WHERE entity=?', [entity]);
-  res.json(rows.map((r) => ({ id: r.id, ...r.data })));
+  const [rows] = await pool.query('SELECT id, nombre, apellidos, email FROM usuarios');
+  res.json(rows);
 });
 
 router.post('/', async (req, res) => {
   const pool = getDb();
-  const data = JSON.stringify(req.body);
-  const [existing] = await pool.query('SELECT id FROM entities WHERE entity=? AND data=?', [entity, data]);
-  if (existing.length > 0) {
-    await pool.query('UPDATE entities SET data=? WHERE id=?', [data, existing[0].id]);
-    res.json({ id: existing[0].id, ...req.body });
-  } else {
-    const [result] = await pool.query('INSERT INTO entities (entity, data) VALUES (?, ?)', [entity, data]);
-    res.json({ id: result.insertId, ...req.body });
-  }
+  const { nombre = 'n/a', apellidos = 'n/a', email = 'n/a' } = req.body;
+  const [result] = await pool.query(
+    'INSERT INTO usuarios (nombre, apellidos, email) VALUES (?, ?, ?)',
+    [nombre, apellidos, email]
+  );
+  res.json({ id: result.insertId, nombre, apellidos, email });
 });
 
 router.put('/:id', async (req, res) => {
   const pool = getDb();
-  await pool.query('UPDATE entities SET data=? WHERE entity=? AND id=?', [
-    JSON.stringify(req.body),
-    entity,
-    req.params.id,
-  ]);
-  res.json({ id: parseInt(req.params.id, 10), ...req.body });
+  const { nombre = 'n/a', apellidos = 'n/a', email = 'n/a' } = req.body;
+  await pool.query(
+    'UPDATE usuarios SET nombre=?, apellidos=?, email=? WHERE id=?',
+    [nombre, apellidos, email, req.params.id]
+  );
+  res.json({ id: parseInt(req.params.id, 10), nombre, apellidos, email });
 });
 
 router.delete('/:id', async (req, res) => {
   const pool = getDb();
-  await pool.query('DELETE FROM entities WHERE entity=? AND id=?', [entity, req.params.id]);
+  await pool.query('DELETE FROM usuarios WHERE id=?', [req.params.id]);
   res.sendStatus(204);
 });
 


### PR DESCRIPTION
## Summary
- add dedicated `usuarios` table and migrate existing records
- update user routes to read/write from relational table instead of generic JSON entity storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a236c6e30c8331a3f46a9175482c31