### PR TITLE
feat: store guardrail programs in dedicated tables

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -13,6 +13,53 @@ async function initDb() {
   await pool.query(
     'CREATE TABLE IF NOT EXISTS entities (id INT AUTO_INCREMENT PRIMARY KEY, entity VARCHAR(255) NOT NULL, data JSON NOT NULL)'
   );
+
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS programas_guardarrail (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      pmtde_id INT NOT NULL,
+      nombre VARCHAR(255) NOT NULL,
+      descripcion TEXT NOT NULL,
+      responsable_id INT NOT NULL,
+      FOREIGN KEY (pmtde_id) REFERENCES entities(id),
+      FOREIGN KEY (responsable_id) REFERENCES entities(id)
+    )`
+  );
+
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS programa_guardarrail_expertos (
+      programa_id INT NOT NULL,
+      usuario_id INT NOT NULL,
+      PRIMARY KEY (programa_id, usuario_id),
+      FOREIGN KEY (programa_id) REFERENCES programas_guardarrail(id) ON DELETE CASCADE,
+      FOREIGN KEY (usuario_id) REFERENCES entities(id)
+    )`
+  );
+
+  const [legacy] = await pool.query(
+    'SELECT id, data FROM entities WHERE entity = "programasGuardarrail"'
+  );
+
+  for (const row of legacy) {
+    const data = JSON.parse(row.data || '{}');
+    const pmtdeId = data.pmtde && data.pmtde.id ? data.pmtde.id : 1;
+    const nombre = data.nombre || 'n/a';
+    const descripcion = data.descripcion || 'n/a';
+    const responsableId = data.responsable && data.responsable.id ? data.responsable.id : 1;
+    await pool.query(
+      'INSERT IGNORE INTO programas_guardarrail (id, pmtde_id, nombre, descripcion, responsable_id) VALUES (?, ?, ?, ?, ?)',
+      [row.id, pmtdeId, nombre, descripcion, responsableId]
+    );
+    if (Array.isArray(data.expertos)) {
+      for (const exp of data.expertos) {
+        const userId = exp && exp.id ? exp.id : 1;
+        await pool.query(
+          'INSERT IGNORE INTO programa_guardarrail_expertos (programa_id, usuario_id) VALUES (?, ?)',
+          [row.id, userId]
+        );
+      }
+    }
+  }
 }
 
 function getDb() {

--- a/backend/routes/programasGuardarrail.js
+++ b/backend/routes/programasGuardarrail.js
@@ -2,41 +2,104 @@ const express = require('express');
 const { getDb } = require('../db');
 
 const router = express.Router();
-const entity = 'programasGuardarrail';
 
 router.get('/', async (req, res) => {
   const pool = getDb();
-  const [rows] = await pool.query('SELECT id, data FROM entities WHERE entity=?', [entity]);
-  res.json(rows.map((r) => ({ id: r.id, ...r.data })));
+  const [rows] = await pool.query(
+    'SELECT id, pmtde_id, nombre, descripcion, responsable_id FROM programas_guardarrail'
+  );
+  if (rows.length === 0) return res.json([]);
+
+  const programaIds = rows.map((r) => r.id);
+  const pmtdeIds = rows.map((r) => r.pmtde_id);
+  const userIds = new Set(rows.map((r) => r.responsable_id));
+
+  const [expertRows] = await pool.query(
+    'SELECT programa_id, usuario_id FROM programa_guardarrail_expertos WHERE programa_id IN (?)',
+    [programaIds]
+  );
+  expertRows.forEach((er) => userIds.add(er.usuario_id));
+
+  const [usuariosRows] = userIds.size
+    ? await pool.query('SELECT id, data FROM entities WHERE id IN (?)', [Array.from(userIds)])
+    : [[], []];
+  const usuariosMap = {};
+  usuariosRows.forEach((u) => {
+    usuariosMap[u.id] = { id: u.id, ...JSON.parse(u.data) };
+  });
+
+  const [pmtdeRows] = await pool.query('SELECT id, data FROM entities WHERE id IN (?)', [pmtdeIds]);
+  const pmtdeMap = {};
+  pmtdeRows.forEach((p) => {
+    pmtdeMap[p.id] = { id: p.id, ...JSON.parse(p.data) };
+  });
+
+  const result = rows.map((r) => ({
+    id: r.id,
+    pmtde: pmtdeMap[r.pmtde_id] || null,
+    nombre: r.nombre,
+    descripcion: r.descripcion,
+    responsable: usuariosMap[r.responsable_id] || null,
+    expertos: expertRows
+      .filter((er) => er.programa_id === r.id)
+      .map((er) => usuariosMap[er.usuario_id])
+      .filter(Boolean),
+  }));
+
+  res.json(result);
 });
 
 router.post('/', async (req, res) => {
   const pool = getDb();
-  const data = JSON.stringify(req.body);
-  const [existing] = await pool.query('SELECT id FROM entities WHERE entity=? AND data=?', [entity, data]);
-  if (existing.length > 0) {
-    await pool.query('UPDATE entities SET data=? WHERE id=?', [data, existing[0].id]);
-    res.json({ id: existing[0].id, ...req.body });
-  } else {
-    const [result] = await pool.query('INSERT INTO entities (entity, data) VALUES (?, ?)', [entity, data]);
-    res.json({ id: result.insertId, ...req.body });
+  const pmtdeId = req.body.pmtde && req.body.pmtde.id ? req.body.pmtde.id : 1;
+  const nombre = req.body.nombre || 'n/a';
+  const descripcion = req.body.descripcion || 'n/a';
+  const respId = req.body.responsable && req.body.responsable.id ? req.body.responsable.id : 1;
+  const [result] = await pool.query(
+    'INSERT INTO programas_guardarrail (pmtde_id, nombre, descripcion, responsable_id) VALUES (?, ?, ?, ?)',
+    [pmtdeId, nombre, descripcion, respId]
+  );
+  const id = result.insertId;
+  if (Array.isArray(req.body.expertos)) {
+    for (const exp of req.body.expertos) {
+      const userId = exp && exp.id ? exp.id : 1;
+      await pool.query(
+        'INSERT INTO programa_guardarrail_expertos (programa_id, usuario_id) VALUES (?, ?)',
+        [id, userId]
+      );
+    }
   }
+  res.json({ id, ...req.body });
 });
 
 router.put('/:id', async (req, res) => {
   const pool = getDb();
-  await pool.query('UPDATE entities SET data=? WHERE entity=? AND id=?', [
-    JSON.stringify(req.body),
-    entity,
-    req.params.id,
-  ]);
+  const pmtdeId = req.body.pmtde && req.body.pmtde.id ? req.body.pmtde.id : 1;
+  const nombre = req.body.nombre || 'n/a';
+  const descripcion = req.body.descripcion || 'n/a';
+  const respId = req.body.responsable && req.body.responsable.id ? req.body.responsable.id : 1;
+  await pool.query(
+    'UPDATE programas_guardarrail SET pmtde_id=?, nombre=?, descripcion=?, responsable_id=? WHERE id=?',
+    [pmtdeId, nombre, descripcion, respId, req.params.id]
+  );
+  await pool.query('DELETE FROM programa_guardarrail_expertos WHERE programa_id=?', [req.params.id]);
+  if (Array.isArray(req.body.expertos)) {
+    for (const exp of req.body.expertos) {
+      const userId = exp && exp.id ? exp.id : 1;
+      await pool.query(
+        'INSERT INTO programa_guardarrail_expertos (programa_id, usuario_id) VALUES (?, ?)',
+        [req.params.id, userId]
+      );
+    }
+  }
   res.json({ id: parseInt(req.params.id, 10), ...req.body });
 });
 
 router.delete('/:id', async (req, res) => {
   const pool = getDb();
-  await pool.query('DELETE FROM entities WHERE entity=? AND id=?', [entity, req.params.id]);
+  await pool.query('DELETE FROM programas_guardarrail WHERE id=?', [req.params.id]);
   res.sendStatus(204);
 });
 
 module.exports = router;
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const path = require('path');
-require('dotenv').config();
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
 
 const { initDb } = require('./db');
 const usuariosRouter = require('./routes/usuarios');


### PR DESCRIPTION
## Summary
- add relational tables and migration for guardrail programs
- implement CRUD API over normalized tables
- load shared environment configuration from root `.env`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a236d7a84c833194782cfd42154096