### PR TITLE
refactor: rename Plan to PlanEstrategico

### DIFF
--- a/backend/routes/planesEstrategicos.js
+++ b/backend/routes/planesEstrategicos.js
@@ -2,7 +2,7 @@ const express = require('express');
 const { getDb } = require('../db');
 
 const router = express.Router();
-const entity = 'planes';
+const entity = 'planEstrategico';
 
 router.get('/', async (req, res) => {
   const pool = getDb();

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,7 +6,7 @@ const { initDb } = require('./db');
 const usuariosRouter = require('./routes/usuarios');
 const pmtdeRouter = require('./routes/pmtde');
 const programasGuardarrailRouter = require('./routes/programasGuardarrail');
-const planesRouter = require('./routes/planes');
+const planesEstrategicosRouter = require('./routes/planesEstrategicos');
 
 const app = express();
 const port = process.env.NODEJS_SERVER_INSIDE_CONTAINER_PORT || 3000;
@@ -17,7 +17,7 @@ app.use(express.static(path.join(__dirname, '..', 'frontend')));
 app.use('/api/usuarios', usuariosRouter);
 app.use('/api/pmtde', pmtdeRouter);
 app.use('/api/programasGuardarrail', programasGuardarrailRouter);
-app.use('/api/planes', planesRouter);
+app.use('/api/planesEstrategicos', planesEstrategicosRouter);
 
 initDb().then(() => {
   app.listen(port, '0.0.0.0', () => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,13 +25,13 @@
   <script type="text/babel" data-presets="env,react" src="js/UsuariosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PmtdeApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailApi.js"></script>
-  <script type="text/babel" data-presets="env,react" src="js/PlanesApi.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/useProcessing.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProcessingBanner.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/UsuariosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PmtdeManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailManager.js"></script>
-  <script type="text/babel" data-presets="env,react" src="js/PlanesManager.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/AdminPanel.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/App.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/index.js"></script>

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -67,7 +67,7 @@ function App() {
             </ListItemIcon>
             <ListItemText primary="Programas Guardarrail" />
           </ListItemButton>
-          <ListItemButton onClick={() => go('planes')}>
+          <ListItemButton onClick={() => go('planesEstrategicos')}>
             <ListItemIcon>
               <span className="material-symbols-outlined">flag</span>
             </ListItemIcon>
@@ -94,7 +94,7 @@ function App() {
             usuarios={usuarios}
           />
         )}
-        {view === 'planes' && <PlanesManager usuarios={usuarios} pmtde={pmtde} />}
+        {view === 'planesEstrategicos' && <PlanesEstrategicosManager usuarios={usuarios} pmtde={pmtde} />}
 
         {view === 'admin' && (
           <AdminPanel

--- a/frontend/js/PlanesEstrategicosApi.js
+++ b/frontend/js/PlanesEstrategicosApi.js
@@ -1,11 +1,11 @@
-const planesApi = {
+const planesEstrategicosApi = {
   list: async () => {
-    const res = await fetch('/api/planes');
+    const res = await fetch('/api/planesEstrategicos');
     return res.json();
   },
   save: async (record) => {
     const method = record.id ? 'PUT' : 'POST';
-    const url = record.id ? `/api/planes/${record.id}` : '/api/planes';
+    const url = record.id ? `/api/planesEstrategicos/${record.id}` : '/api/planesEstrategicos';
     const res = await fetch(url, {
       method,
       headers: { 'Content-Type': 'application/json' },
@@ -14,6 +14,6 @@ const planesApi = {
     return res.json();
   },
   remove: async (id) => {
-    await fetch(`/api/planes/${id}`, { method: 'DELETE' });
+    await fetch(`/api/planesEstrategicos/${id}`, { method: 'DELETE' });
   },
 };

--- a/frontend/js/PlanesEstrategicosManager.js
+++ b/frontend/js/PlanesEstrategicosManager.js
@@ -1,6 +1,6 @@
-function PlanesManager({ usuarios, pmtde = [] }) {
+function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
   const empty = { pmtde: null, nombre: '', descripcion: '', responsable: null, expertos: [] };
-  const [planes, setPlanes] = React.useState([]);
+  const [planesEstrategicos, setPlanesEstrategicos] = React.useState([]);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [current, setCurrent] = React.useState(empty);
   const [view, setView] = React.useState('table');
@@ -15,7 +15,7 @@ function PlanesManager({ usuarios, pmtde = [] }) {
   const { busy, seconds, perform } = useProcessing();
 
   React.useEffect(() => {
-    planesApi.list().then(setPlanes);
+    planesEstrategicosApi.list().then(setPlanesEstrategicos);
   }, []);
 
   const openNew = () => {
@@ -30,9 +30,9 @@ function PlanesManager({ usuarios, pmtde = [] }) {
 
   const handleSave = async () => {
     await perform(async () => {
-      await planesApi.save(current);
-      const list = await planesApi.list();
-      setPlanes(list);
+      await planesEstrategicosApi.save(current);
+      const list = await planesEstrategicosApi.list();
+      setPlanesEstrategicos(list);
       setDialogOpen(false);
     });
   };
@@ -40,13 +40,13 @@ function PlanesManager({ usuarios, pmtde = [] }) {
   const handleDelete = (id) => {
     if (!window.confirm('¿Eliminar plan estratégico?')) return;
     perform(async () => {
-      await planesApi.remove(id);
-      const list = await planesApi.list();
-      setPlanes(list);
+      await planesEstrategicosApi.remove(id);
+      const list = await planesEstrategicosApi.list();
+      setPlanesEstrategicos(list);
     });
   };
 
-  const filtered = planes
+  const filtered = planesEstrategicos
     .filter((p) => {
       const txt = normalize(
         `${p.nombre} ${p.descripcion || ''} ${p.pmtde ? p.pmtde.nombre : ''} ${


### PR DESCRIPTION
## Summary
- rename Plan entity to PlanEstrategico across backend and frontend
- expose PlanEstrategico API at `/api/planesEstrategicos`
- adjust navigation and scripts to new PlanEstrategico naming

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2368b1c8083319d3d72231e860444