### PR TITLE
feat: persist strategic plans in dedicated tables

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -13,8 +13,6 @@ async function initDb() {
   await pool.query(
     'CREATE TABLE IF NOT EXISTS entities (id INT AUTO_INCREMENT PRIMARY KEY, entity VARCHAR(255) NOT NULL, data JSON NOT NULL)'
   );
-
-
   await pool.query(
     `CREATE TABLE IF NOT EXISTS programas_guardarrail (
       id INT AUTO_INCREMENT PRIMARY KEY,
@@ -33,6 +31,28 @@ async function initDb() {
       usuario_id INT NOT NULL,
       PRIMARY KEY (programa_id, usuario_id),
       FOREIGN KEY (programa_id) REFERENCES programas_guardarrail(id) ON DELETE CASCADE,
+      FOREIGN KEY (usuario_id) REFERENCES entities(id)
+    )`
+  );
+
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS planes_estrategicos (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      pmtde_id INT NOT NULL,
+      nombre VARCHAR(255) NOT NULL,
+      descripcion TEXT NOT NULL,
+      responsable_id INT NOT NULL,
+      FOREIGN KEY (pmtde_id) REFERENCES entities(id),
+      FOREIGN KEY (responsable_id) REFERENCES entities(id)
+    )`
+  );
+
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS plan_estrategico_expertos (
+      plan_id INT NOT NULL,
+      usuario_id INT NOT NULL,
+      PRIMARY KEY (plan_id, usuario_id),
+      FOREIGN KEY (plan_id) REFERENCES planes_estrategicos(id) ON DELETE CASCADE,
       FOREIGN KEY (usuario_id) REFERENCES entities(id)
     )`
   );
@@ -60,6 +80,33 @@ async function initDb() {
         );
       }
     }
+  }
+
+  const [oldPlans] = await pool.query(
+    'SELECT id, data FROM entities WHERE entity = "planEstrategico"'
+  );
+
+  for (const row of oldPlans) {
+    const data = JSON.parse(row.data || '{}');
+    const pmtdeId = data.pmtde && data.pmtde.id ? data.pmtde.id : 1;
+    const nombre = data.nombre || 'n/a';
+    const descripcion = data.descripcion || 'n/a';
+    const responsableId = data.responsable && data.responsable.id ? data.responsable.id : 1;
+    await pool.query(
+      'INSERT IGNORE INTO planes_estrategicos (id, pmtde_id, nombre, descripcion, responsable_id) VALUES (?, ?, ?, ?, ?)',
+      [row.id, pmtdeId, nombre, descripcion, responsableId]
+    );
+    if (Array.isArray(data.expertos)) {
+      for (const exp of data.expertos) {
+        const userId = exp && exp.id ? exp.id : 1;
+        await pool.query(
+          'INSERT IGNORE INTO plan_estrategico_expertos (plan_id, usuario_id) VALUES (?, ?)',
+          [row.id, userId]
+        );
+      }
+    }
+    await pool.query('DELETE FROM entities WHERE id=?', [row.id]);
+  }
 
   await pool.query(
     `CREATE TABLE IF NOT EXISTS usuarios (
@@ -83,7 +130,6 @@ async function initDb() {
       [row.id, nombre, apellidos, email]
     );
     await pool.query('DELETE FROM entities WHERE id=?', [row.id]);
-
   }
 }
 

--- a/backend/routes/planesEstrategicos.js
+++ b/backend/routes/planesEstrategicos.js
@@ -2,41 +2,108 @@ const express = require('express');
 const { getDb } = require('../db');
 
 const router = express.Router();
-const entity = 'planEstrategico';
 
 router.get('/', async (req, res) => {
   const pool = getDb();
-  const [rows] = await pool.query('SELECT id, data FROM entities WHERE entity=?', [entity]);
-  res.json(rows.map((r) => ({ id: r.id, ...r.data })));
+  const [rows] = await pool.query(
+    'SELECT id, pmtde_id, nombre, descripcion, responsable_id FROM planes_estrategicos'
+  );
+  if (rows.length === 0) return res.json([]);
+
+  const planIds = rows.map((r) => r.id);
+  const pmtdeIds = rows.map((r) => r.pmtde_id);
+  const userIds = new Set(rows.map((r) => r.responsable_id));
+
+  const [expertRows] = await pool.query(
+    'SELECT plan_id, usuario_id FROM plan_estrategico_expertos WHERE plan_id IN (?)',
+    [planIds]
+  );
+  expertRows.forEach((er) => userIds.add(er.usuario_id));
+
+  const [usuariosRows] = userIds.size
+    ? await pool.query('SELECT id, data FROM entities WHERE id IN (?)', [Array.from(userIds)])
+    : [[], []];
+  const usuariosMap = {};
+  usuariosRows.forEach((u) => {
+    usuariosMap[u.id] = { id: u.id, ...JSON.parse(u.data) };
+  });
+
+  const [pmtdeRows] = await pool.query('SELECT id, data FROM entities WHERE id IN (?)', [pmtdeIds]);
+  const pmtdeMap = {};
+  pmtdeRows.forEach((p) => {
+    pmtdeMap[p.id] = { id: p.id, ...JSON.parse(p.data) };
+  });
+
+  const result = rows.map((r) => ({
+    id: r.id,
+    pmtde: pmtdeMap[r.pmtde_id] || null,
+    nombre: r.nombre,
+    descripcion: r.descripcion,
+    responsable: usuariosMap[r.responsable_id] || null,
+    expertos: expertRows
+      .filter((er) => er.plan_id === r.id)
+      .map((er) => usuariosMap[er.usuario_id])
+      .filter(Boolean),
+  }));
+
+  res.json(result);
 });
 
 router.post('/', async (req, res) => {
   const pool = getDb();
-  const data = JSON.stringify(req.body);
-  const [existing] = await pool.query('SELECT id FROM entities WHERE entity=? AND data=?', [entity, data]);
-  if (existing.length > 0) {
-    await pool.query('UPDATE entities SET data=? WHERE id=?', [data, existing[0].id]);
-    res.json({ id: existing[0].id, ...req.body });
-  } else {
-    const [result] = await pool.query('INSERT INTO entities (entity, data) VALUES (?, ?)', [entity, data]);
-    res.json({ id: result.insertId, ...req.body });
+  const pmtdeId = req.body.pmtde && req.body.pmtde.id ? req.body.pmtde.id : 1;
+  const nombre = req.body.nombre || 'n/a';
+  const descripcion = req.body.descripcion || 'n/a';
+  const respId =
+    req.body.responsable && req.body.responsable.id ? req.body.responsable.id : 1;
+  const [result] = await pool.query(
+    'INSERT INTO planes_estrategicos (pmtde_id, nombre, descripcion, responsable_id) VALUES (?, ?, ?, ?)',
+    [pmtdeId, nombre, descripcion, respId]
+  );
+  const id = result.insertId;
+  if (Array.isArray(req.body.expertos)) {
+    for (const exp of req.body.expertos) {
+      const userId = exp && exp.id ? exp.id : 1;
+      await pool.query(
+        'INSERT INTO plan_estrategico_expertos (plan_id, usuario_id) VALUES (?, ?)',
+        [id, userId]
+      );
+    }
   }
+  res.json({ id, ...req.body });
 });
 
 router.put('/:id', async (req, res) => {
   const pool = getDb();
-  await pool.query('UPDATE entities SET data=? WHERE entity=? AND id=?', [
-    JSON.stringify(req.body),
-    entity,
+  const pmtdeId = req.body.pmtde && req.body.pmtde.id ? req.body.pmtde.id : 1;
+  const nombre = req.body.nombre || 'n/a';
+  const descripcion = req.body.descripcion || 'n/a';
+  const respId =
+    req.body.responsable && req.body.responsable.id ? req.body.responsable.id : 1;
+  await pool.query(
+    'UPDATE planes_estrategicos SET pmtde_id=?, nombre=?, descripcion=?, responsable_id=? WHERE id=?',
+    [pmtdeId, nombre, descripcion, respId, req.params.id]
+  );
+  await pool.query('DELETE FROM plan_estrategico_expertos WHERE plan_id=?', [
     req.params.id,
   ]);
+  if (Array.isArray(req.body.expertos)) {
+    for (const exp of req.body.expertos) {
+      const userId = exp && exp.id ? exp.id : 1;
+      await pool.query(
+        'INSERT INTO plan_estrategico_expertos (plan_id, usuario_id) VALUES (?, ?)',
+        [req.params.id, userId]
+      );
+    }
+  }
   res.json({ id: parseInt(req.params.id, 10), ...req.body });
 });
 
 router.delete('/:id', async (req, res) => {
   const pool = getDb();
-  await pool.query('DELETE FROM entities WHERE entity=? AND id=?', [entity, req.params.id]);
+  await pool.query('DELETE FROM planes_estrategicos WHERE id=?', [req.params.id]);
   res.sendStatus(204);
 });
 
 module.exports = router;
+


### PR DESCRIPTION
## Summary
- persist strategic plans in new `planes_estrategicos` and `plan_estrategico_expertos` tables
- migrate legacy `planEstrategico` JSON records into relational structure
- expose CRUD API for strategic plans using the new relational model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a238e752648331be35329d40bfeff3