### PR TITLE
Ensure ProgramasGuardarrail dialogs meet editing guidelines

### DIFF
--- a/frontend/js/ProgramaGuardarrailManager.js
+++ b/frontend/js/ProgramaGuardarrailManager.js
@@ -316,7 +316,11 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
         </Box>
       )}
 
-      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="md" fullWidth>
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        PaperProps={{ sx: { minWidth: '50vw' } }}
+      >
         <DialogTitle>{current.id ? 'Editar programa guardarrail' : 'Nuevo programa guardarrail'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
           <Autocomplete


### PR DESCRIPTION
## Summary
- ensure program guardrail editing/creation dialog uses minimum width of 50% of viewport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23c9ce1c08331ac5f8c35c5ff3669