### PR TITLE
feat: add parameter management

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -15,6 +15,24 @@ async function initDb() {
     'CREATE TABLE IF NOT EXISTS entities (id INT AUTO_INCREMENT PRIMARY KEY, entity VARCHAR(255) NOT NULL, data JSON NOT NULL)'
   );
 
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS parametros (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      nombre VARCHAR(255) NOT NULL UNIQUE,
+      valor VARCHAR(255) NOT NULL DEFAULT 'n/a',
+      valor_defecto VARCHAR(255) NOT NULL DEFAULT 'n/a'
+    )`
+  );
+
+  const [appName] = await pool.query(
+    'SELECT id FROM parametros WHERE nombre="Nombre de la aplicación"'
+  );
+  if (appName.length === 0) {
+    await pool.query(
+      'INSERT INTO parametros (nombre, valor, valor_defecto) VALUES ("Nombre de la aplicación", "Aplicación", "Aplicación")'
+    );
+  }
+
 
   await pool.query(
     `CREATE TABLE IF NOT EXISTS usuarios (

--- a/backend/routes/parametros.js
+++ b/backend/routes/parametros.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const router = express.Router();
+const { getDb } = require('../db');
+
+// List all parameters
+router.get('/', async (req, res) => {
+  const [rows] = await getDb().query(
+    'SELECT id, nombre, valor, valor_defecto FROM parametros'
+  );
+  res.json(rows);
+});
+
+// Update parameter value
+router.put('/:id', async (req, res) => {
+  const { valor } = req.body;
+  await getDb().query('UPDATE parametros SET valor=? WHERE id=?', [valor || 'n/a', req.params.id]);
+  const [rows] = await getDb().query(
+    'SELECT id, nombre, valor, valor_defecto FROM parametros WHERE id=?',
+    [req.params.id]
+  );
+  res.json(rows[0]);
+});
+
+// Reset parameter to default
+router.post('/:id/reset', async (req, res) => {
+  await getDb().query(
+    'UPDATE parametros SET valor=valor_defecto WHERE id=?',
+    [req.params.id]
+  );
+  const [rows] = await getDb().query(
+    'SELECT id, nombre, valor, valor_defecto FROM parametros WHERE id=?',
+    [req.params.id]
+  );
+  res.json(rows[0]);
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,6 +7,7 @@ const usuariosRouter = require('./routes/usuarios');
 const pmtdeRouter = require('./routes/pmtde');
 const programasGuardarrailRouter = require('./routes/programasGuardarrail');
 const planesEstrategicosRouter = require('./routes/planesEstrategicos');
+const parametrosRouter = require('./routes/parametros');
 
 const app = express();
 const port = process.env.NODEJS_SERVER_INSIDE_CONTAINER_PORT || 3000;
@@ -18,6 +19,7 @@ app.use('/api/usuarios', usuariosRouter);
 app.use('/api/pmtde', pmtdeRouter);
 app.use('/api/programasGuardarrail', programasGuardarrailRouter);
 app.use('/api/planesEstrategicos', planesEstrategicosRouter);
+app.use('/api/parametros', parametrosRouter);
 
 initDb().then(() => {
   app.listen(port, '0.0.0.0', () => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,12 +26,14 @@
   <script type="text/babel" data-presets="env,react" src="js/PmtdeApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosApi.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/ParametrosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/useProcessing.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProcessingBanner.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/UsuariosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PmtdeManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosManager.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/ParametrosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/AdminPanel.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/App.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/index.js"></script>

--- a/frontend/js/AdminPanel.js
+++ b/frontend/js/AdminPanel.js
@@ -1,13 +1,21 @@
-function AdminPanel({ usuarios, setUsuarios, pmtde, setPmtde }) {
+function AdminPanel({ usuarios, setUsuarios, pmtde, setPmtde, parametros, setParametros, setAppName }) {
   const [tab, setTab] = React.useState(0);
   return (
     <Box>
       <Tabs value={tab} onChange={(e, v) => setTab(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Tab label="Usuarios" />
         <Tab label="PMTDE" />
+        <Tab label="Parámetros" />
       </Tabs>
       {tab === 0 && <UsuariosManager usuarios={usuarios} setUsuarios={setUsuarios} />}
       {tab === 1 && <PmtdeManager usuarios={usuarios} pmtde={pmtde} setPmtde={setPmtde} />}
+      {tab === 2 && (
+        <ParametrosManager
+          parametros={parametros}
+          setParametros={setParametros}
+          setAppName={setAppName}
+        />
+      )}
     </Box>
   );
 }

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -5,6 +5,8 @@ function App() {
   const [usuarios, setUsuarios] = React.useState([]);
   const [pmtde, setPmtde] = React.useState([]);
   const [programasGuardarrail, setProgramasGuardarrail] = React.useState([]);
+  const [parametros, setParametros] = React.useState([]);
+  const [appName, setAppName] = React.useState('Aplicación');
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   const [profileAnchor, setProfileAnchor] = React.useState(null);
 
@@ -16,6 +18,11 @@ function App() {
     usuariosApi.list().then(setUsuarios);
     pmtdeApi.list().then(setPmtde);
     programasGuardarrailApi.list().then(setProgramasGuardarrail);
+    parametrosApi.list().then((params) => {
+      setParametros(params);
+      const nameParam = params.find((p) => p.nombre === 'Nombre de la aplicación');
+      if (nameParam) setAppName(nameParam.valor);
+    });
   }, []);
 
   return (
@@ -28,7 +35,7 @@ function App() {
             </span>
           </IconButton>
           <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            PMTDE
+            {appName}
           </Typography>
           <Tooltip title="Administración">
             <IconButton color="inherit" onClick={() => setView('admin')}>
@@ -102,6 +109,9 @@ function App() {
             setUsuarios={setUsuarios}
             pmtde={pmtde}
             setPmtde={setPmtde}
+            parametros={parametros}
+            setParametros={setParametros}
+            setAppName={setAppName}
           />
         )}
         {view === 'home' && <Box sx={{ p: 2 }}>Bienvenido</Box>}

--- a/frontend/js/ParametrosApi.js
+++ b/frontend/js/ParametrosApi.js
@@ -1,0 +1,18 @@
+const parametrosApi = {
+  list: async () => {
+    const res = await fetch('/api/parametros');
+    return res.json();
+  },
+  save: async (param) => {
+    const res = await fetch(`/api/parametros/${param.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ valor: param.valor }),
+    });
+    return res.json();
+  },
+  reset: async (id) => {
+    const res = await fetch(`/api/parametros/${id}/reset`, { method: 'POST' });
+    return res.json();
+  },
+};

--- a/frontend/js/ParametrosManager.js
+++ b/frontend/js/ParametrosManager.js
@@ -1,0 +1,52 @@
+function ParametrosManager({ parametros, setParametros, setAppName }) {
+  React.useEffect(() => {
+    if (!parametros.length) {
+      parametrosApi.list().then(setParametros);
+    }
+  }, []);
+
+  const updateLocal = (id, valor) => {
+    setParametros(parametros.map((p) => (p.id === id ? { ...p, valor } : p)));
+  };
+
+  const save = async (param) => {
+    const updated = await parametrosApi.save(param);
+    setParametros(parametros.map((p) => (p.id === param.id ? updated : p)));
+    if (updated.nombre === 'Nombre de la aplicación') {
+      setAppName(updated.valor);
+    }
+  };
+
+  const reset = async (param) => {
+    const updated = await parametrosApi.reset(param.id);
+    setParametros(parametros.map((p) => (p.id === param.id ? updated : p)));
+    if (updated.nombre === 'Nombre de la aplicación') {
+      setAppName(updated.valor);
+    }
+  };
+
+  return (
+    <List>
+      {parametros.map((p) => (
+        <ListItem key={p.id} sx={{ gap: 1 }}>
+          <ListItemText
+            primary={p.nombre}
+            secondary={`Por defecto: ${p.valor_defecto}`}
+            sx={{ flex: 1 }}
+          />
+          <TextField
+            size="small"
+            value={p.valor}
+            onChange={(e) => updateLocal(p.id, e.target.value)}
+          />
+          <Button variant="contained" onClick={() => save(p)}>
+            Guardar
+          </Button>
+          <Button variant="outlined" onClick={() => reset(p)}>
+            Restablecer
+          </Button>
+        </ListItem>
+      ))}
+    </List>
+  );
+}


### PR DESCRIPTION
## Summary
- add Parametros API endpoints and database table
- manage parameters from admin panel
- display configurable application name from parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23ee8044083318e922fee3ec3efa3