### PR TITLE
refactor: centralize csv export

### DIFF
--- a/frontend/js/PlanesEstrategicosManager.js
+++ b/frontend/js/PlanesEstrategicosManager.js
@@ -92,15 +92,7 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
       p.responsable ? p.responsable.email : '',
       p.expertos.map((e) => e.email).join('|'),
     ]);
-    let csv = header.join(';') + '\n';
-    rows.forEach((r) => {
-      csv += r.join(';') + '\n';
-    });
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${formatDate()} PlanesEstrategicos.csv`;
-    link.click();
+    exportToCSV(header, rows, 'PlanesEstrategicos');
   };
 
   const exportPDF = () => {

--- a/frontend/js/PmtdeManager.js
+++ b/frontend/js/PmtdeManager.js
@@ -64,15 +64,7 @@ function PmtdeManager({ pmtde, setPmtde, usuarios }) {
   const exportCSV = () => {
     const header = ['Nombre', 'Descripción', 'Propietario'];
     const rows = filtered.map((p) => [p.nombre, p.descripcion, p.propietario ? p.propietario.email : '']);
-    let csv = header.join(';') + '\n';
-    rows.forEach((r) => {
-      csv += r.join(';') + '\n';
-    });
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${formatDate()} PMTDE.csv`;
-    link.click();
+    exportToCSV(header, rows, 'PMTDE');
   };
 
   const exportPDF = () => {

--- a/frontend/js/ProgramaGuardarrailManager.js
+++ b/frontend/js/ProgramaGuardarrailManager.js
@@ -84,15 +84,7 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
       p.responsable ? p.responsable.email : '',
       p.expertos.map((e) => e.email).join(',')
     ]);
-    let csv = header.join(';') + '\n';
-    rows.forEach((r) => {
-      csv += r.join(';') + '\n';
-    });
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${formatDate()} ProgramasGuardarrail.csv`;
-    link.click();
+    exportToCSV(header, rows, 'ProgramasGuardarrail');
   };
 
   const exportPDF = () => {

--- a/frontend/js/UsuariosManager.js
+++ b/frontend/js/UsuariosManager.js
@@ -52,15 +52,7 @@ function UsuariosManager({ usuarios, setUsuarios }) {
   const exportCSV = () => {
     const header = ['Nombre', 'Apellidos', 'Email'];
     const rows = filtered.map((u) => [u.nombre, u.apellidos, u.email]);
-    let csv = header.join(';') + '\n';
-    rows.forEach((r) => {
-      csv += r.join(';') + '\n';
-    });
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${formatDate()} Usuarios.csv`;
-    link.click();
+    exportToCSV(header, rows, 'Usuarios');
   };
 
   const exportPDF = () => {

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -35,7 +35,24 @@ const {
 const formatDate = () => {
   const d = new Date();
   const pad = (n) => n.toString().padStart(2, '0');
-  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())} ${pad(d.getHours())}${pad(d.getMinutes())}`;
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+const exportToCSV = (headers, rows, entity) => {
+  const formatValue = (v) => {
+    if (v instanceof Date) return `"${v.toISOString().split('T')[0]}"`;
+    if (typeof v === 'string' && /^\d{4}-\d{2}-\d{2}/.test(v)) return `"${v}"`;
+    return v ?? '';
+    };
+  let csv = headers.join(';') + '\n';
+  rows.forEach((r) => {
+    csv += r.map(formatValue).join(';') + '\n';
+  });
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = `${formatDate()} ${entity}.csv`;
+  link.click();
 };
 
 const normalize = (s) =>


### PR DESCRIPTION
## Summary
- centralize CSV export into helper to enforce semicolon delimiters and quoted dates
- ensure export filenames use `yyyyMMdd HH:MM` format per AGENTS_08

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23ec206f08331bdec3218ddbb9eb8