### PR TITLE
feat: add SQL import export capabilities

### DIFF
--- a/backend/routes/importExport.js
+++ b/backend/routes/importExport.js
@@ -1,0 +1,99 @@
+const express = require('express');
+const { getDb } = require('../db');
+
+const router = express.Router();
+
+router.get('/export', async (req, res) => {
+  const db = getDb();
+  const tables = [
+    'parametros',
+    'usuarios',
+    'pmtde',
+    'programas_guardarrail',
+    'programa_guardarrail_expertos',
+    'planes_estrategicos',
+    'plan_estrategico_expertos',
+  ];
+  let sql = '';
+  for (const table of tables) {
+    const [rows] = await db.query(`SELECT * FROM ${table}`);
+    for (const row of rows) {
+      const cols = Object.keys(row).map((c) => `\`${c}\``).join(', ');
+      const vals = Object.values(row)
+        .map((v) =>
+          v === null
+            ? 'NULL'
+            : `'${String(v).replace(/'/g, "''")}'`
+        )
+        .join(', ');
+      sql += `INSERT INTO ${table} (${cols}) VALUES (${vals});\n`;
+    }
+  }
+  const [appNameRow] = await db.query(
+    'SELECT valor FROM parametros WHERE nombre="Nombre de la aplicación"'
+  );
+  const appName = appNameRow[0] ? appNameRow[0].valor : 'aplicacion';
+  const now = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  const fileName = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())} ${pad(now.getHours())}${pad(now.getMinutes())} exportación de datos ${appName}.sql`;
+  res.setHeader('Content-Type', 'application/sql');
+  res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+  res.send(sql);
+});
+
+router.post('/import', async (req, res) => {
+  const { sql, tables } = req.body;
+  const db = getDb();
+  const summary = [];
+  let logs = '';
+  const importedIds = {};
+  for (const t of tables) {
+    importedIds[t] = new Set();
+    summary.push({ entity: t, ok: 0, errors: 0 });
+  }
+  const insertRegex = /INSERT INTO `?(\w+)`? \(([^)]+)\) VALUES \(([^)]+)\);/g;
+  let match;
+  while ((match = insertRegex.exec(sql)) !== null) {
+    const table = match[1];
+    if (!tables.includes(table)) continue;
+    const cols = match[2]
+      .split(',')
+      .map((c) => c.trim().replace(/`/g, ''));
+    const rawVals = match[3].split(',');
+    const vals = rawVals.map((v) =>
+      v.trim().replace(/^'(.*)'$/s, '$1').replace(/''/g, "'")
+    );
+    const obj = {};
+    cols.forEach((c, i) => {
+      obj[c] = vals[i];
+    });
+    const id = obj.id;
+    importedIds[table].add(id);
+    try {
+      const placeholders = cols.map(() => '?').join(', ');
+      const updates = cols.map((c) => `${c}=VALUES(${c})`).join(', ');
+      await db.query(
+        `INSERT INTO ${table} (${cols.join(', ')}) VALUES (${placeholders}) ON DUPLICATE KEY UPDATE ${updates}`,
+        Object.values(obj)
+      );
+      summary.find((s) => s.entity === table).ok++;
+    } catch (e) {
+      logs += `${table} id ${id}: ${e.message}\n`;
+      summary.find((s) => s.entity === table).errors++;
+    }
+  }
+  for (const t of tables) {
+    const ids = Array.from(importedIds[t]);
+    if (ids.length) {
+      await db.query(
+        `DELETE FROM ${t} WHERE id NOT IN (${ids.map(() => '?').join(',')})`,
+        ids
+      );
+    } else {
+      await db.query(`DELETE FROM ${t}`);
+    }
+  }
+  res.json({ summary, logs });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ const pmtdeRouter = require('./routes/pmtde');
 const programasGuardarrailRouter = require('./routes/programasGuardarrail');
 const planesEstrategicosRouter = require('./routes/planesEstrategicos');
 const parametrosRouter = require('./routes/parametros');
+const importExportRouter = require('./routes/importExport');
 
 const app = express();
 const port = process.env.NODEJS_SERVER_INSIDE_CONTAINER_PORT || 3000;
@@ -20,6 +21,7 @@ app.use('/api/pmtde', pmtdeRouter);
 app.use('/api/programasGuardarrail', programasGuardarrailRouter);
 app.use('/api/planesEstrategicos', planesEstrategicosRouter);
 app.use('/api/parametros', parametrosRouter);
+app.use('/api/import-export', importExportRouter);
 
 initDb().then(() => {
   app.listen(port, '0.0.0.0', () => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,6 +27,7 @@
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ParametrosApi.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/ImportExportApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/useProcessing.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProcessingBanner.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/UsuariosManager.js"></script>
@@ -34,6 +35,7 @@
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ParametrosManager.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/ImportExportManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/AdminPanel.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/App.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/index.js"></script>

--- a/frontend/js/AdminPanel.js
+++ b/frontend/js/AdminPanel.js
@@ -6,6 +6,7 @@ function AdminPanel({ usuarios, setUsuarios, pmtde, setPmtde, parametros, setPar
         <Tab label="Usuarios" />
         <Tab label="PMTDE" />
         <Tab label="Parámetros" />
+        <Tab label="Importación / Exportación" />
       </Tabs>
       {tab === 0 && <UsuariosManager usuarios={usuarios} setUsuarios={setUsuarios} />}
       {tab === 1 && <PmtdeManager usuarios={usuarios} pmtde={pmtde} setPmtde={setPmtde} />}
@@ -16,6 +17,7 @@ function AdminPanel({ usuarios, setUsuarios, pmtde, setPmtde, parametros, setPar
           setAppName={setAppName}
         />
       )}
+      {tab === 3 && <ImportExportManager />}
     </Box>
   );
 }

--- a/frontend/js/ImportExportApi.js
+++ b/frontend/js/ImportExportApi.js
@@ -1,0 +1,13 @@
+const importExportApi = {
+  exportData: () => {
+    window.location = '/api/import-export/export';
+  },
+  importData: async (sql, tables) => {
+    const res = await fetch('/api/import-export/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sql, tables }),
+    });
+    return res.json();
+  },
+};

--- a/frontend/js/ImportExportManager.js
+++ b/frontend/js/ImportExportManager.js
@@ -1,0 +1,104 @@
+function ImportExportManager() {
+  const [sqlText, setSqlText] = React.useState('');
+  const [entities, setEntities] = React.useState([]);
+  const [selected, setSelected] = React.useState([]);
+  const [summary, setSummary] = React.useState([]);
+  const [logs, setLogs] = React.useState('');
+
+  const handleFile = async (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      const text = await file.text();
+      setSqlText(text);
+      const found = Array.from(
+        new Set(
+          [...text.matchAll(/INSERT INTO `?(\w+)`?/g)].map((m) => m[1])
+        )
+      );
+      setEntities(found);
+      setSelected(found);
+    }
+  };
+
+  const toggle = (ent) => {
+    setSelected((prev) =>
+      prev.includes(ent) ? prev.filter((e) => e !== ent) : [...prev, ent]
+    );
+  };
+
+  const doImport = async () => {
+    const result = await importExportApi.importData(sqlText, selected);
+    setSummary(result.summary || []);
+    setLogs(result.logs || '');
+  };
+
+  return (
+    <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h6">Exportación de datos</Typography>
+      <Button variant="contained" onClick={() => importExportApi.exportData()}>
+        Exportar datos
+      </Button>
+
+      <Typography variant="h6" sx={{ mt: 4 }}>
+        Importación de datos
+      </Typography>
+      <Button variant="contained" component="label">
+        Seleccionar archivo de datos
+        <input hidden type="file" onChange={handleFile} />
+      </Button>
+
+      {entities.length > 0 && (
+        <Box>
+          <Typography>Entidades:</Typography>
+          {entities.map((ent) => (
+            <FormControlLabel
+              key={ent}
+              control={
+                <Checkbox
+                  checked={selected.includes(ent)}
+                  onChange={() => toggle(ent)}
+                />
+              }
+              label={ent}
+            />
+          ))}
+          <Button variant="contained" onClick={doImport} sx={{ mt: 2 }}>
+            Importar datos
+          </Button>
+        </Box>
+      )}
+
+      {summary.length > 0 && (
+        <Box>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Entidad</TableCell>
+                <TableCell>Correctos</TableCell>
+                <TableCell>Errores</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {summary.map((s) => (
+                <TableRow key={s.entity}>
+                  <TableCell>{s.entity}</TableCell>
+                  <TableCell>{s.ok}</TableCell>
+                  <TableCell>{s.errors}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <Typography variant="h6" sx={{ mt: 2 }}>
+            Logs
+          </Typography>
+          <TextField
+            multiline
+            fullWidth
+            value={logs}
+            InputProps={{ readOnly: true }}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin tab for Importación / Exportación
- implement API and backend to export database as SQL and import selected tables

## Testing
- `npm test`
- `node backend/server.js` *(fails: Identifier 'legacy' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68a24053bd488331b965fa9dff7acc5c