### PR TITLE
fix: ensure db service reachable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Variables de entorno compartidas para servidor y contenedores
 DB_USER=root
 DB_PASSWORD=example
-DB_HOST=localhost
+DB_HOST=mariadb
 DB_PORT=3306
 DB_NAME=pmtde
 DB_ROOT_PASSWORD=rootpass

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Programa Marco de Transformación Digital Efectiva
 ## Desarrollo local
 
 1. Copia el fichero `.env.example` a `.env` y modifica los valores necesarios.
+   El valor por defecto de `DB_HOST` es `mariadb`, que corresponde al nombre del
+   contenedor de base de datos. Si ejecutas el servidor fuera de Docker deberás
+   cambiarlo a `localhost` o a la dirección que utilice tu base de datos.
 2. Instala las dependencias con:
    ```bash
    npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - "${FRONT_PORT}:${NODEJS_SERVER_INSIDE_CONTAINER_PORT}"
     depends_on:
-      - db
-  db:
+      - mariadb
+  mariadb:
     image: mariadb:11
     env_file:
       - .env


### PR DESCRIPTION
## Summary
- rename database service to `mariadb` and update env usage
- document `DB_HOST` defaults to `mariadb`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a245c291608331ba27b5d6988de996