### PR TITLE
feat: add codigo to planes estrategicos

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -73,6 +73,7 @@ async function initDb() {
   await pool.query(
     `CREATE TABLE IF NOT EXISTS planes_estrategicos (
       id INT AUTO_INCREMENT PRIMARY KEY,
+      codigo VARCHAR(8) NOT NULL DEFAULT 'N/A',
       pmtde_id INT NOT NULL DEFAULT 1,
       nombre VARCHAR(255) NOT NULL DEFAULT 'n/a',
       descripcion TEXT NOT NULL DEFAULT 'n/a',
@@ -80,6 +81,14 @@ async function initDb() {
       FOREIGN KEY (pmtde_id) REFERENCES pmtde(id),
       FOREIGN KEY (responsable_id) REFERENCES usuarios(id)
     )`
+  );
+
+  await pool.query(
+    `ALTER TABLE planes_estrategicos
+      ADD COLUMN IF NOT EXISTS codigo VARCHAR(8) NOT NULL DEFAULT 'N/A'`
+  );
+  await pool.query(
+    "UPDATE planes_estrategicos SET codigo='N/A' WHERE codigo IS NULL OR codigo=''"
   );
 
   await pool.query(

--- a/backend/routes/planesEstrategicos.js
+++ b/backend/routes/planesEstrategicos.js
@@ -6,7 +6,7 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   const pool = getDb();
   const [rows] = await pool.query(
-    'SELECT id, pmtde_id, nombre, descripcion, responsable_id FROM planes_estrategicos'
+    'SELECT id, codigo, pmtde_id, nombre, descripcion, responsable_id FROM planes_estrategicos'
   );
   if (rows.length === 0) return res.json([]);
 
@@ -36,6 +36,7 @@ router.get('/', async (req, res) => {
 
   const result = rows.map((r) => ({
     id: r.id,
+    codigo: r.codigo,
     pmtde: pmtdeMap[r.pmtde_id] || null,
     nombre: r.nombre,
     descripcion: r.descripcion,
@@ -51,14 +52,15 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   const pool = getDb();
+  const codigo = (req.body.codigo || 'N/A').toUpperCase().substring(0, 8);
   const pmtdeId = req.body.pmtde && req.body.pmtde.id ? req.body.pmtde.id : 1;
   const nombre = req.body.nombre || 'n/a';
   const descripcion = req.body.descripcion || 'n/a';
   const respId =
     req.body.responsable && req.body.responsable.id ? req.body.responsable.id : 1;
   const [result] = await pool.query(
-    'INSERT INTO planes_estrategicos (pmtde_id, nombre, descripcion, responsable_id) VALUES (?, ?, ?, ?)',
-    [pmtdeId, nombre, descripcion, respId]
+    'INSERT INTO planes_estrategicos (codigo, pmtde_id, nombre, descripcion, responsable_id) VALUES (?, ?, ?, ?, ?)',
+    [codigo, pmtdeId, nombre, descripcion, respId]
   );
   const id = result.insertId;
   if (Array.isArray(req.body.expertos)) {
@@ -75,14 +77,15 @@ router.post('/', async (req, res) => {
 
 router.put('/:id', async (req, res) => {
   const pool = getDb();
+  const codigo = (req.body.codigo || 'N/A').toUpperCase().substring(0, 8);
   const pmtdeId = req.body.pmtde && req.body.pmtde.id ? req.body.pmtde.id : 1;
   const nombre = req.body.nombre || 'n/a';
   const descripcion = req.body.descripcion || 'n/a';
   const respId =
     req.body.responsable && req.body.responsable.id ? req.body.responsable.id : 1;
   await pool.query(
-    'UPDATE planes_estrategicos SET pmtde_id=?, nombre=?, descripcion=?, responsable_id=? WHERE id=?',
-    [pmtdeId, nombre, descripcion, respId, req.params.id]
+    'UPDATE planes_estrategicos SET codigo=?, pmtde_id=?, nombre=?, descripcion=?, responsable_id=? WHERE id=?',
+    [codigo, pmtdeId, nombre, descripcion, respId, req.params.id]
   );
   await pool.query('DELETE FROM plan_estrategico_expertos WHERE plan_id=?', [
     req.params.id,

--- a/frontend/js/PlanesEstrategicosApi.js
+++ b/frontend/js/PlanesEstrategicosApi.js
@@ -6,10 +6,14 @@ const planesEstrategicosApi = {
   save: async (record) => {
     const method = record.id ? 'PUT' : 'POST';
     const url = record.id ? `/api/planesEstrategicos/${record.id}` : '/api/planesEstrategicos';
+    const payload = {
+      ...record,
+      codigo: (record.codigo || '').toUpperCase().substring(0, 8),
+    };
     const res = await fetch(url, {
       method,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(record),
+      body: JSON.stringify(payload),
     });
     return res.json();
   },

--- a/frontend/js/PlanesEstrategicosManager.js
+++ b/frontend/js/PlanesEstrategicosManager.js
@@ -1,6 +1,14 @@
 function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
-  const empty = { pmtde: null, nombre: '', descripcion: '', responsable: null, expertos: [] };
+  const empty = {
+    codigo: '',
+    pmtde: null,
+    nombre: '',
+    descripcion: '',
+    responsable: null,
+    expertos: [],
+  };
   const columnsConfig = [
+    { key: 'codigo', label: 'Código', render: (p) => p.codigo },
     { key: 'pmtde', label: 'PMTDE', render: (p) => (p.pmtde ? p.pmtde.nombre : '') },
     { key: 'nombre', label: 'Nombre', render: (p) => p.nombre },
     {
@@ -71,7 +79,7 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
   const filtered = planesEstrategicos
     .filter((p) => {
       const txt = normalize(
-        `${p.nombre} ${p.descripcion || ''} ${p.pmtde ? p.pmtde.nombre : ''} ${
+        `${p.codigo} ${p.nombre} ${p.descripcion || ''} ${p.pmtde ? p.pmtde.nombre : ''} ${
           p.responsable ? p.responsable.nombre + ' ' + p.responsable.apellidos : ''
         } ${p.expertos.map((e) => e.nombre + ' ' + e.apellidos).join(' ')}`
       );
@@ -106,8 +114,9 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
     });
 
   const exportCSV = () => {
-    const header = ['PMTDE', 'Nombre', 'Descripción', 'Responsable', 'Grupo de expertos'];
+    const header = ['Código', 'PMTDE', 'Nombre', 'Descripción', 'Responsable', 'Grupo de expertos'];
     const rows = filtered.map((p) => [
+      p.codigo,
       p.pmtde ? p.pmtde.nombre : '',
       p.nombre,
       p.descripcion,
@@ -124,9 +133,9 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
     let y = 20;
     filtered.forEach((p) => {
       doc.text(
-        `${p.nombre} - ${p.responsable ? p.responsable.email : ''} - ${
-          p.pmtde ? p.pmtde.nombre : ''
-        }`,
+        `${p.codigo} - ${p.nombre} - ${
+          p.responsable ? p.responsable.email : ''
+        } - ${p.pmtde ? p.pmtde.nombre : ''}`,
         10,
         y
       );
@@ -279,6 +288,7 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
             <Card key={p.id} sx={{ width: 250 }}>
               <CardContent>
                 <Typography variant="h6">{p.nombre}</Typography>
+                <Typography variant="body2">{p.codigo}</Typography>
                 <Typography variant="body2">{p.pmtde ? p.pmtde.nombre : ''}</Typography>
                 <Typography variant="body2" component="div">
                   <span dangerouslySetInnerHTML={{ __html: marked.parse(p.descripcion || '') }} />
@@ -309,19 +319,27 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
 
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar plan estratégico' : 'Nuevo plan estratégico'}</DialogTitle>
-        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-          <Autocomplete
-            options={pmtde}
-            getOptionLabel={(p) => p.nombre}
-            value={current.pmtde}
-            onChange={(e, val) => setCurrent({ ...current, pmtde: val })}
-            renderInput={(params) => <TextField {...params} label="PMTDE*" />}
-          />
-          <TextField
-            label="Nombre del plan*"
-            value={current.nombre}
-            onChange={(e) => setCurrent({ ...current, nombre: e.target.value })}
-          />
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+        <Autocomplete
+          options={pmtde}
+          getOptionLabel={(p) => p.nombre}
+          value={current.pmtde}
+          onChange={(e, val) => setCurrent({ ...current, pmtde: val })}
+          renderInput={(params) => <TextField {...params} label="PMTDE*" />}
+        />
+        <TextField
+          label="Código*"
+          value={current.codigo}
+          inputProps={{ maxLength: 8 }}
+          onChange={(e) =>
+            setCurrent({ ...current, codigo: e.target.value.toUpperCase().slice(0, 8) })
+          }
+        />
+        <TextField
+          label="Nombre del plan*"
+          value={current.nombre}
+          onChange={(e) => setCurrent({ ...current, nombre: e.target.value })}
+        />
           <TextField
             label="Descripción*"
             multiline


### PR DESCRIPTION
## Summary
- add uppercase codigo column to planes estrategicos table and API
- expose codigo in strategic plan listings, exports, and forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2464962f883318a39d35db57205e5