### PR TITLE
Add base64 favicon for digital transformation

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PMTDE</title>
+  <!-- Favicon base64 representing digital transformation strategy -->
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iNCIgcnk9IjQiIGZpbGw9IiMxOTc2ZDIiLz48cGF0aCBkPSJNMTIgNlYzTDggN2w0IDRWOGMyLjIgMCA0IDEuOCA0IDQgMCAuOS0uMyAxLjctLjggMi40bDEuNSAxLjVDMTcuNSAxNSAxOCAxMy42IDE4IDEyYzAtMy4zLTIuNy02LTYtNnptLTQuMiAyLjZDNi41IDggNiA5LjQgNiAxMWMwIDMuMyAyLjcgNiA2IDZ2M2w0LTQtNC00djNjLTIuMiAwLTQtMS44LTQtNCAwLS45LjMtMS43LjgtMi40TDguMyA4LjZ6IiBmaWxsPSIjZmZmIi8+PHJlY3QgeD0iMTEiIHk9IjExIiB3aWR0aD0iMiIgaGVpZ2h0PSIyIiBmaWxsPSIjMTk3NmQyIi8+PC9zdmc+" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
   <style>
     th {


### PR DESCRIPTION
## Summary
- Embed base64-encoded favicon representing the digital transformation strategy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a24cbe61308331a8b597d4a5a4c45d