### PR TITLE
fix: include user preferences in import export

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -124,7 +124,7 @@ async function initDb() {
     `CREATE TABLE IF NOT EXISTS preferencias_usuario (
       usuario VARCHAR(255) NOT NULL DEFAULT 'anonimo',
       tabla VARCHAR(255) NOT NULL DEFAULT 'n/a',
-      columnas JSON NOT NULL DEFAULT '[]',
+      columnas TEXT NOT NULL DEFAULT '[]',
       PRIMARY KEY (usuario, tabla)
     )`
   );


### PR DESCRIPTION
## Summary
- add `preferencias_usuario` table to import/export cycle
- stringify object values during export and skip deletions for tables without IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24bb8ce348331ad0e0a8bca05d8f2