### PR TITLE
fix: import export FormControlLabel

### DIFF
--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -31,6 +31,7 @@ const {
   Menu,
   MenuItem,
   Checkbox,
+  FormControlLabel,
 } = MaterialUI;
 
 const formatDate = () => {


### PR DESCRIPTION
## Summary
- fix missing FormControlLabel import for import/export selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2516f66f88331bfe9f1486ff93478