### PR TITLE
docs: add data model documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,4 @@ Debes asegurarte de que el código de este proyecto cumple con todas las instruc
 - docs/guardrails/AGENTS_15 LDAP.MD
 - docs/guardrails/AGENTS_16 API.MD
 - docs/guardrails/AGENTS_17 Estructura codigo.MD
+- docs/guardrails/AGENTS_18 Documentación.md

--- a/docs/funcional/01 Modelo de datos.md
+++ b/docs/funcional/01 Modelo de datos.md
@@ -1,0 +1,70 @@
+---
+title: "Modelo de datos"
+description: "Descripción de las entidades y campos de la aplicación"
+---
+
+# Modelo de datos
+
+## parametros
+| Campo | Tipo de datos | Valor por defecto | Referencia | Tipo de referencia |
+|-------|---------------|-------------------|------------|--------------------|
+| id | INT AUTO_INCREMENT | - | - | - |
+| nombre | VARCHAR(255) | - | - | - |
+| valor | VARCHAR(255) | 'n/a' | - | - |
+| valor_defecto | VARCHAR(255) | 'n/a' | - | - |
+
+## usuarios
+| Campo | Tipo de datos | Valor por defecto | Referencia | Tipo de referencia |
+|-------|---------------|-------------------|------------|--------------------|
+| id | INT AUTO_INCREMENT | - | - | - |
+| nombre | VARCHAR(255) | 'n/a' | - | - |
+| apellidos | VARCHAR(255) | 'n/a' | - | - |
+| email | VARCHAR(255) | 'n/a' | - | - |
+
+## pmtde
+| Campo | Tipo de datos | Valor por defecto | Referencia | Tipo de referencia |
+|-------|---------------|-------------------|------------|--------------------|
+| id | INT AUTO_INCREMENT | - | - | - |
+| nombre | VARCHAR(255) | 'n/a' | - | - |
+| descripcion | TEXT | 'n/a' | - | - |
+| propietario_id | INT | 1 | usuarios.id | Sin cascada |
+
+## programas_guardarrail
+| Campo | Tipo de datos | Valor por defecto | Referencia | Tipo de referencia |
+|-------|---------------|-------------------|------------|--------------------|
+| id | INT AUTO_INCREMENT | - | - | - |
+| codigo | VARCHAR(8) | 'N/A' | - | - |
+| pmtde_id | INT | 1 | pmtde.id | Sin cascada |
+| nombre | VARCHAR(255) | 'n/a' | - | - |
+| descripcion | TEXT | 'n/a' | - | - |
+| responsable_id | INT | 1 | usuarios.id | Sin cascada |
+
+## programa_guardarrail_expertos
+| Campo | Tipo de datos | Valor por defecto | Referencia | Tipo de referencia |
+|-------|---------------|-------------------|------------|--------------------|
+| programa_id | INT | - | programas_guardarrail.id | En cascada |
+| usuario_id | INT | - | usuarios.id | Sin cascada |
+
+## planes_estrategicos
+| Campo | Tipo de datos | Valor por defecto | Referencia | Tipo de referencia |
+|-------|---------------|-------------------|------------|--------------------|
+| id | INT AUTO_INCREMENT | - | - | - |
+| codigo | VARCHAR(8) | 'N/A' | - | - |
+| pmtde_id | INT | 1 | pmtde.id | Sin cascada |
+| nombre | VARCHAR(255) | 'n/a' | - | - |
+| descripcion | TEXT | 'n/a' | - | - |
+| responsable_id | INT | 1 | usuarios.id | Sin cascada |
+
+## plan_estrategico_expertos
+| Campo | Tipo de datos | Valor por defecto | Referencia | Tipo de referencia |
+|-------|---------------|-------------------|------------|--------------------|
+| plan_id | INT | - | planes_estrategicos.id | En cascada |
+| usuario_id | INT | - | usuarios.id | Sin cascada |
+
+## preferencias_usuario
+| Campo | Tipo de datos | Valor por defecto | Referencia | Tipo de referencia |
+|-------|---------------|-------------------|------------|--------------------|
+| usuario | VARCHAR(255) | 'anonimo' | - | - |
+| tabla | VARCHAR(255) | 'n/a' | - | - |
+| columnas | TEXT | '[]' | - | - |
+


### PR DESCRIPTION
## Summary
- reference new AGENTS_18 documentation requirement in root instructions
- add data model documentation describing tables, defaults, and references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25a424f44833185352d899735e76d