### PR TITLE
feat: add guardrail principles management

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -107,6 +107,23 @@ async function initDb() {
   );
 
   await pool.query(
+    `CREATE TABLE IF NOT EXISTS principios_guardarrail (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      programa_id INT NOT NULL DEFAULT 1,
+      codigo VARCHAR(255) NOT NULL DEFAULT 'n/a',
+      titulo VARCHAR(255) NOT NULL DEFAULT 'n/a',
+      descripcion TEXT NOT NULL DEFAULT 'n/a',
+      FOREIGN KEY (programa_id) REFERENCES programas_guardarrail(id) ON DELETE CASCADE
+    )`
+  );
+  await pool.query(
+    "ALTER TABLE principios_guardarrail ADD COLUMN IF NOT EXISTS codigo VARCHAR(255) NOT NULL DEFAULT 'n/a'"
+  );
+  await pool.query(
+    "UPDATE principios_guardarrail SET codigo='n/a' WHERE codigo IS NULL OR codigo=''"
+  );
+
+  await pool.query(
     `CREATE TABLE IF NOT EXISTS planes_estrategicos (
       id INT AUTO_INCREMENT PRIMARY KEY,
       codigo VARCHAR(8) NOT NULL DEFAULT 'n/a',

--- a/backend/routes/principiosGuardarrail.js
+++ b/backend/routes/principiosGuardarrail.js
@@ -1,0 +1,76 @@
+const express = require('express');
+const { getDb } = require('../db');
+
+const router = express.Router();
+
+async function generateCodigo(programaId) {
+  const pool = getDb();
+  const [progRows] = await pool.query('SELECT codigo FROM programas_guardarrail WHERE id=?', [programaId]);
+  const progCode = progRows.length ? progRows[0].codigo : 'N/A';
+  const [rows] = await pool.query(
+    'SELECT MAX(CAST(SUBSTRING_INDEX(codigo, ".P", -1) AS UNSIGNED)) AS maxnum FROM principios_guardarrail WHERE programa_id=?',
+    [programaId]
+  );
+  const next = (rows[0].maxnum || 0) + 1;
+  return `${progCode}.P${next}`;
+}
+
+router.get('/', async (req, res) => {
+  const pool = getDb();
+  const [rows] = await pool.query(
+    `SELECT pg.id, pg.codigo, pg.titulo, pg.descripcion, pg.programa_id,
+            pr.codigo AS programa_codigo, pr.nombre AS programa_nombre
+       FROM principios_guardarrail pg
+       JOIN programas_guardarrail pr ON pg.programa_id = pr.id`
+  );
+  const result = rows.map((r) => ({
+    id: r.id,
+    codigo: r.codigo,
+    titulo: r.titulo,
+    descripcion: r.descripcion,
+    programa: { id: r.programa_id, codigo: r.programa_codigo, nombre: r.programa_nombre },
+  }));
+  res.json(result);
+});
+
+router.post('/', async (req, res) => {
+  const pool = getDb();
+  const programaId = req.body.programa && req.body.programa.id ? req.body.programa.id : 1;
+  const titulo = req.body.titulo || 'n/a';
+  const descripcion = req.body.descripcion || 'n/a';
+  const codigo = await generateCodigo(programaId);
+  const [result] = await pool.query(
+    'INSERT INTO principios_guardarrail (programa_id, codigo, titulo, descripcion) VALUES (?, ?, ?, ?)',
+    [programaId, codigo, titulo, descripcion]
+  );
+  res.json({ id: result.insertId, codigo, ...req.body });
+});
+
+router.put('/:id', async (req, res) => {
+  const pool = getDb();
+  const programaId = req.body.programa && req.body.programa.id ? req.body.programa.id : 1;
+  const titulo = req.body.titulo || 'n/a';
+  const descripcion = req.body.descripcion || 'n/a';
+  let codigo = req.body.codigo || 'n/a';
+  const [current] = await pool.query('SELECT programa_id FROM principios_guardarrail WHERE id=?', [req.params.id]);
+  const oldProg = current.length ? current[0].programa_id : programaId;
+  if (programaId !== oldProg) {
+    codigo = await generateCodigo(programaId);
+  }
+  await pool.query(
+    'UPDATE principios_guardarrail SET programa_id=?, codigo=?, titulo=?, descripcion=? WHERE id=?',
+    [programaId, codigo, titulo, descripcion, req.params.id]
+  );
+  res.json({ id: parseInt(req.params.id, 10), codigo, ...req.body });
+});
+
+router.delete('/:id', async (req, res) => {
+  const pool = getDb();
+  if (req.query.confirm !== 'true') {
+    return res.status(400).json({ message: 'Confirmar eliminación' });
+  }
+  await pool.query('DELETE FROM principios_guardarrail WHERE id=?', [req.params.id]);
+  res.sendStatus(204);
+});
+
+module.exports = router;

--- a/backend/routes/programasGuardarrail.js
+++ b/backend/routes/programasGuardarrail.js
@@ -79,6 +79,10 @@ router.post('/', async (req, res) => {
         );
       }
     }
+    await pool.query(
+      'UPDATE principios_guardarrail SET codigo = CONCAT(?, ".P", SUBSTRING_INDEX(codigo, ".P", -1)) WHERE programa_id=?',
+      [codigo, id]
+    );
     return res.json({ id, codigo, ...req.body });
   }
   const [result] = await pool.query(
@@ -108,6 +112,10 @@ router.put('/:id', async (req, res) => {
   await pool.query(
     'UPDATE programas_guardarrail SET codigo=?, pmtde_id=?, nombre=?, descripcion=?, responsable_id=? WHERE id=?',
     [codigo, pmtdeId, nombre, descripcion, respId, req.params.id]
+  );
+  await pool.query(
+    'UPDATE principios_guardarrail SET codigo = CONCAT(?, ".P", SUBSTRING_INDEX(codigo, ".P", -1)) WHERE programa_id=?',
+    [codigo, req.params.id]
   );
   await pool.query('DELETE FROM programa_guardarrail_expertos WHERE programa_id=?', [req.params.id]);
   if (Array.isArray(req.body.expertos)) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ const authRouter = require('./routes/auth');
 const usuariosRouter = require('./routes/usuarios');
 const pmtdeRouter = require('./routes/pmtde');
 const programasGuardarrailRouter = require('./routes/programasGuardarrail');
+const principiosGuardarrailRouter = require('./routes/principiosGuardarrail');
 const planesEstrategicosRouter = require('./routes/planesEstrategicos');
 const parametrosRouter = require('./routes/parametros');
 
@@ -41,6 +42,7 @@ app.use((req, res, next) => {
 app.use('/api/usuarios', usuariosRouter);
 app.use('/api/pmtde', pmtdeRouter);
 app.use('/api/programasGuardarrail', programasGuardarrailRouter);
+app.use('/api/principiosGuardarrail', principiosGuardarrailRouter);
 app.use('/api/planesEstrategicos', planesEstrategicosRouter);
 app.use('/api/parametros', parametrosRouter);
 

--- a/docs/funcional/01 Modelo de datos.md
+++ b/docs/funcional/01 Modelo de datos.md
@@ -45,6 +45,15 @@ description: "Descripción de las entidades y campos de la aplicación"
 | programa_id | INT |  | programas_guardarrail.id | SI |
 | usuario_id | INT |  | usuarios.id | SI |
 
+## principios_guardarrail
+| Campo | Tipo de datos | Valor por defecto | Referencia | Eliminación en cascada |
+|-------|---------------|-------------------|------------|------------------------|
+| id | INT AUTO_INCREMENT |  |  |  |
+| programa_id | INT | 1 | programas_guardarrail.id | SI |
+| codigo | VARCHAR(255) | 'n/a' |  |  |
+| titulo | VARCHAR(255) | 'n/a' |  |  |
+| descripcion | TEXT | 'n/a' |  |  |
+
 ## planes_estrategicos
 | Campo | Tipo de datos | Valor por defecto | Referencia | Eliminación en cascada |
 |-------|---------------|-------------------|------------|------------------------|

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,6 +30,7 @@
   <script type="text/babel" data-presets="env,react" src="js/UsuariosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PmtdeApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailApi.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/PrincipioGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ParametrosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ImportExportApi.js"></script>
@@ -40,6 +41,7 @@
   <script type="text/babel" data-presets="env,react" src="js/UsuariosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PmtdeManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailManager.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/PrincipioGuardarrailManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ParametrosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ImportExportManager.js"></script>

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -5,6 +5,7 @@ function App() {
   const [usuarios, setUsuarios] = React.useState([]);
   const [pmtde, setPmtde] = React.useState([]);
   const [programasGuardarrail, setProgramasGuardarrail] = React.useState([]);
+  const [principiosGuardarrail, setPrincipiosGuardarrail] = React.useState([]);
   const [parametros, setParametros] = React.useState([]);
   const [appName, setAppName] = React.useState('Aplicación');
   const [drawerOpen, setDrawerOpen] = React.useState(false);
@@ -20,6 +21,7 @@ function App() {
     usuariosApi.list().then(setUsuarios);
     pmtdeApi.list().then(setPmtde);
     programasGuardarrailApi.list().then(setProgramasGuardarrail);
+    principiosGuardarrailApi.list().then(setPrincipiosGuardarrail);
     parametrosApi.list().then((params) => {
       setParametros(params);
       const nameParam = params.find((p) => p.nombre === 'Nombre de la aplicación');
@@ -127,6 +129,12 @@ function App() {
             </ListItemIcon>
             <ListItemText primary="Programas Guardarrail" />
           </ListItemButton>
+          <ListItemButton sx={{ pl: 4 }} onClick={() => go('principiosGuardarrail')}>
+            <ListItemIcon>
+              <span className="material-symbols-outlined">rule</span>
+            </ListItemIcon>
+            <ListItemText primary="Principios Guardarrail" />
+          </ListItemButton>
           <ListItemButton onClick={() => go('planesEstrategicos')}>
             <ListItemIcon>
               <span className="material-symbols-outlined">flag</span>
@@ -152,6 +160,18 @@ function App() {
             setProgramasGuardarrail={setProgramasGuardarrail}
             pmtde={pmtde}
             usuarios={usuarios}
+            refreshPrincipios={() =>
+              principiosGuardarrailApi
+                .list()
+                .then(setPrincipiosGuardarrail)
+            }
+          />
+        )}
+        {view === 'principiosGuardarrail' && (
+          <PrincipioGuardarrailManager
+            principiosGuardarrail={principiosGuardarrail}
+            setPrincipiosGuardarrail={setPrincipiosGuardarrail}
+            programasGuardarrail={programasGuardarrail}
           />
         )}
         {view === 'planesEstrategicos' && <PlanesEstrategicosManager usuarios={usuarios} pmtde={pmtde} />}

--- a/frontend/js/PrincipioGuardarrailApi.js
+++ b/frontend/js/PrincipioGuardarrailApi.js
@@ -1,0 +1,21 @@
+const principiosGuardarrailApi = {
+  list: async () => {
+    const res = await fetch('/api/principiosGuardarrail');
+    return res.json();
+  },
+  save: async (record) => {
+    const method = record.id ? 'PUT' : 'POST';
+    const url = record.id
+      ? `/api/principiosGuardarrail/${record.id}`
+      : '/api/principiosGuardarrail';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(record),
+    });
+    return res.json();
+  },
+  remove: async (id) => {
+    await fetch(`/api/principiosGuardarrail/${id}?confirm=true`, { method: 'DELETE' });
+  },
+};

--- a/frontend/js/PrincipioGuardarrailManager.js
+++ b/frontend/js/PrincipioGuardarrailManager.js
@@ -1,0 +1,273 @@
+function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuardarrail, programasGuardarrail }) {
+  const columnsConfig = [
+    {
+      key: 'programa',
+      label: 'Programa',
+      render: (p) => (p.programa ? p.programa.nombre : ''),
+    },
+    { key: 'codigo', label: 'Código', render: (p) => p.codigo },
+    { key: 'titulo', label: 'Título', render: (p) => p.titulo },
+    {
+      key: 'descripcion',
+      label: 'Descripción',
+      render: (p) => (
+        <span dangerouslySetInnerHTML={{ __html: marked.parse(p.descripcion || '') }} />
+      ),
+    },
+  ];
+  const { columns, openSelector, selector } = useColumnPreferences('principios_guardarrail', columnsConfig);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [current, setCurrent] = React.useState({ programa: null, codigo: '', titulo: '', descripcion: '' });
+  const [view, setView] = React.useState('table');
+  const [filterOpen, setFilterOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+  const [progFilter, setProgFilter] = React.useState([]);
+  const [sortField, setSortField] = React.useState('titulo');
+  const [sortDir, setSortDir] = React.useState('asc');
+  const { busy, seconds, perform } = useProcessing();
+
+  const openNew = () => {
+    setCurrent({ programa: null, codigo: '', titulo: '', descripcion: '' });
+    setDialogOpen(true);
+  };
+
+  const openEdit = (pr) => {
+    setCurrent(pr);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    await perform(async () => {
+      await principiosGuardarrailApi.save(current);
+      const list = await principiosGuardarrailApi.list();
+      setPrincipiosGuardarrail(list);
+      setDialogOpen(false);
+    });
+  };
+
+  const handleDelete = (id) => {
+    if (!window.confirm('¿Eliminar principio guardarrail? Esta acción es irreversible.')) return;
+    perform(async () => {
+      await principiosGuardarrailApi.remove(id);
+      const list = await principiosGuardarrailApi.list();
+      setPrincipiosGuardarrail(list);
+    });
+  };
+
+  const filtered = principiosGuardarrail
+    .filter((p) => {
+      const txt = normalize(
+        `${p.programa ? p.programa.nombre : ''} ${p.codigo} ${p.titulo} ${p.descripcion || ''}`
+      );
+      const searchMatch = txt.includes(normalize(search));
+      const progMatch = progFilter.length
+        ? progFilter.some((pf) => pf.id === (p.programa && p.programa.id))
+        : true;
+      return searchMatch && progMatch;
+    })
+    .sort((a, b) => {
+      const getVal = (obj) => {
+        if (sortField === 'programa') return normalize(obj.programa ? obj.programa.nombre : '');
+        return normalize(obj[sortField] || '');
+      };
+      const valA = getVal(a);
+      const valB = getVal(b);
+      if (valA < valB) return sortDir === 'asc' ? -1 : 1;
+      if (valA > valB) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+
+  const exportCSV = () => {
+    const header = ['Programa', 'Código', 'Título', 'Descripción'];
+    const rows = filtered.map((p) => [
+      p.programa ? p.programa.nombre : '',
+      p.codigo,
+      p.titulo,
+      p.descripcion,
+    ]);
+    exportToCSV(header, rows, 'PrincipiosGuardarrail');
+  };
+
+  const exportPDF = () => {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text('Principios Guardarrail', 10, 10);
+    let y = 20;
+    filtered.forEach((p) => {
+      doc.text(
+        `${p.codigo} - ${p.titulo} - ${p.programa ? p.programa.nombre : ''}`,
+        10,
+        y
+      );
+      y += 10;
+      if (y > 280) {
+        doc.addPage();
+        y = 10;
+      }
+    });
+    doc.save(`${formatDate()} PrincipiosGuardarrail.pdf`);
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+        <Button onClick={openNew} disabled={busy}>Nuevo</Button>
+        <Tooltip title="Exportar CSV">
+          <IconButton onClick={exportCSV} disabled={busy}>
+            <span className="material-symbols-outlined">file_download</span>
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <IconButton onClick={exportPDF} disabled={busy}>
+            <span className="material-symbols-outlined">picture_as_pdf</span>
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Filtrar">
+          <IconButton onClick={() => setFilterOpen(!filterOpen)} disabled={busy}>
+            <span className="material-symbols-outlined">filter_alt</span>
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Columnas">
+          <IconButton onClick={openSelector} disabled={busy}>
+            <span className="material-symbols-outlined">view_column</span>
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={view === 'table' ? 'Ver como tarjetas' : 'Ver como tabla'}>
+          <IconButton onClick={() => setView(view === 'table' ? 'cards' : 'table')} disabled={busy}>
+            <span className="material-symbols-outlined">
+              {view === 'table' ? 'view_module' : 'table_rows'}
+            </span>
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      {filterOpen && (
+        <Box sx={{ mb: 2, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          <TextField
+            label="Buscar"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <Autocomplete
+            multiple
+            options={programasGuardarrail}
+            getOptionLabel={(p) => p.nombre}
+            value={progFilter}
+            onChange={(e, val) => setProgFilter(val)}
+            renderInput={(params) => <TextField {...params} label="Programa" />}
+            sx={{ minWidth: 200 }}
+          />
+          <Button onClick={() => { setSearch(''); setProgFilter([]); }}>Reset</Button>
+        </Box>
+      )}
+
+      {selector}
+
+      {view === 'table' ? (
+        <Table>
+          <TableHead sx={tableHeadSx}>
+            <TableRow>
+              {columns.map((col) => (
+                <TableCell key={col.key} sortDirection={sortField === col.key ? sortDir : false}>
+                  <TableSortLabel
+                    active={sortField === col.key}
+                    direction={sortField === col.key ? sortDir : 'asc'}
+                    onClick={() => {
+                      const isAsc = sortField === col.key && sortDir === 'asc';
+                      setSortField(col.key);
+                      setSortDir(isAsc ? 'desc' : 'asc');
+                    }}
+                  >
+                    {col.label}
+                  </TableSortLabel>
+                </TableCell>
+              ))}
+              <TableCell>Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered.map((p) => (
+              <TableRow key={p.id}>
+                {columns.map((col) => (
+                  <TableCell key={col.key}>{col.render(p)}</TableCell>
+                ))}
+                <TableCell>
+                  <Tooltip title="Editar">
+                    <IconButton onClick={() => openEdit(p)} disabled={busy}>
+                      <span className="material-symbols-outlined">edit</span>
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar">
+                    <IconButton onClick={() => handleDelete(p.id)} disabled={busy}>
+                      <span className="material-symbols-outlined">delete</span>
+                    </IconButton>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {filtered.map((p) => (
+            <Card key={p.id} sx={{ width: 250 }}>
+              <CardContent>
+                <Typography variant="h6">{p.codigo} - {p.titulo}</Typography>
+                <Typography variant="body2">{p.programa ? p.programa.nombre : ''}</Typography>
+                <Typography variant="body2" component="div">
+                  <span dangerouslySetInnerHTML={{ __html: marked.parse(p.descripcion || '') }} />
+                </Typography>
+                <Box sx={{ mt: 1 }}>
+                  <Tooltip title="Editar">
+                    <IconButton onClick={() => openEdit(p)} disabled={busy}>
+                      <span className="material-symbols-outlined">edit</span>
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar">
+                    <IconButton onClick={() => handleDelete(p.id)} disabled={busy}>
+                      <span className="material-symbols-outlined">delete</span>
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              </CardContent>
+            </Card>
+          ))}
+        </Box>
+      )}
+
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        PaperProps={{ sx: { minWidth: '50vw' } }}
+      >
+        <DialogTitle>{current.id ? 'Editar principio guardarrail' : 'Nuevo principio guardarrail'}</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <Autocomplete
+            options={programasGuardarrail}
+            getOptionLabel={(p) => p.nombre}
+            value={current.programa}
+            onChange={(e, val) => setCurrent({ ...current, programa: val })}
+            renderInput={(params) => <TextField {...params} label="Programa*" />}
+          />
+          <TextField label="Código" value={current.codigo} disabled />
+          <TextField
+            label="Título*"
+            value={current.titulo}
+            onChange={(e) => setCurrent({ ...current, titulo: e.target.value })}
+          />
+          <TextField
+            label="Descripción*"
+            multiline
+            minRows={3}
+            value={current.descripcion}
+            onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)} disabled={busy}>Cancelar</Button>
+          <Button onClick={handleSave} disabled={busy}>Guardar</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/frontend/js/ProgramaGuardarrailManager.js
+++ b/frontend/js/ProgramaGuardarrailManager.js
@@ -1,4 +1,4 @@
-function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarrail, pmtde, usuarios }) {
+function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarrail, pmtde, usuarios, refreshPrincipios }) {
   const columnsConfig = [
     { key: 'pmtde', label: 'PMTDE', render: (p) => (p.pmtde ? p.pmtde.nombre : '') },
     { key: 'codigo', label: 'Código', render: (p) => p.codigo },
@@ -50,6 +50,7 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
       await programasGuardarrailApi.save(current);
       const list = await programasGuardarrailApi.list();
       setProgramasGuardarrail(list);
+      if (refreshPrincipios) await refreshPrincipios();
       setDialogOpen(false);
     });
   };
@@ -60,6 +61,7 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
       await programasGuardarrailApi.remove(id);
       const list = await programasGuardarrailApi.list();
       setProgramasGuardarrail(list);
+      if (refreshPrincipios) await refreshPrincipios();
     });
   };
 


### PR DESCRIPTION
## Summary
- add backend CRUD and database table for guardrail principles with auto code generation
- update program routes to propagate code changes to related principles
- add frontend management UI and navigation for guardrail principles, including exports and filtering
- document new guardrail principles entity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25f4097108331ab9f5c09725d29a2