### PR TITLE
Reorganiza menú de guardarrail

### DIFF
--- a/docs/funcional/use-cases/programas-guardarrailes/01 Programas guardarrailes.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/01 Programas guardarrailes.md
@@ -21,7 +21,7 @@ La aplicación permite gestionar programas guardarrail vinculados a los PMTDE.
 - Existen usuarios para seleccionar como responsable o expertos.
 
 **Flujo principal:**
-1. El usuario abre el submenú "Programas guardarrail".
+1. El usuario abre el menú "Programas guardarrail" y selecciona el submenú "Programas".
 2. Elige "Crear nuevo programa".
 3. Introduce:
    - PMTDE asociado (obligatorio).
@@ -84,7 +84,7 @@ La aplicación permite gestionar programas guardarrail vinculados a los PMTDE.
 **Actores principales:** Usuario.
 
 **Flujo principal:**
-1. El usuario abre el submenú "Programas guardarrail".
+1. El usuario abre el menú "Programas guardarrail" y selecciona el submenú "Programas".
 2. El sistema muestra para cada programa:
    - PMTDE asociado.
    - Código.

--- a/docs/funcional/use-cases/programas-guardarrailes/02 Principios guardarrailes.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/02 Principios guardarrailes.md
@@ -20,7 +20,7 @@ La aplicación permite gestionar principios específicos vinculados a los progra
 - Existe al menos un Plan Estratégico registrado.
 
 **Flujo principal:**
-1. El usuario abre el submenú "Principios específicos".
+1. El usuario abre el menú "Programas guardarrail" y selecciona el submenú "Principios guardarrail".
 2. Elige "Nuevo principio".
 3. Introduce:
    - Plan estratégico al que pertenece (obligatorio).
@@ -74,7 +74,7 @@ La aplicación permite gestionar principios específicos vinculados a los progra
 **Actores principales:** Usuario.
 
 **Flujo principal:**
-1. El usuario abre el submenú "Principios específicos".
+1. El usuario abre el menú "Programas guardarrail" y selecciona el submenú "Principios guardarrail".
 2. El sistema muestra para cada principio:
    - Código.
    - Plan estratégico.

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -13,6 +13,7 @@ function App() {
   const [user, setUser] = React.useState(null);
   const [useAuth, setUseAuth] = React.useState(false);
   const [planesMenuOpen, setPlanesMenuOpen] = React.useState(false);
+  const [programasMenuOpen, setProgramasMenuOpen] = React.useState(false);
 
   const go = (v) => setView(v);
 
@@ -131,12 +132,33 @@ function App() {
         }}
       >
         <List>
-          <ListItemButton onClick={() => go('programasGuardarrail')}>
+          <ListItemButton
+            onClick={() => {
+              go('programasGuardarrail');
+              setProgramasMenuOpen((o) => !o);
+            }}
+          >
             <ListItemIcon>
               <span className="material-symbols-outlined">layers</span>
             </ListItemIcon>
             <ListItemText primary="Programas Guardarrail" />
+            <span className="material-symbols-outlined">
+              {programasMenuOpen ? 'expand_less' : 'expand_more'}
+            </span>
           </ListItemButton>
+          <Collapse in={programasMenuOpen} timeout="auto" unmountOnExit>
+            <List component="div" disablePadding>
+              <ListItemButton sx={{ pl: 4 }} onClick={() => go('programasGuardarrail')}>
+                <ListItemText primary="Programas" />
+              </ListItemButton>
+              <ListItemButton sx={{ pl: 4 }} onClick={() => go('principiosGuardarrail')}>
+                <ListItemIcon>
+                  <span className="material-symbols-outlined">rule</span>
+                </ListItemIcon>
+                <ListItemText primary="Principios Guardarrail" />
+              </ListItemButton>
+            </List>
+          </Collapse>
 
           <ListItemButton onClick={() => setPlanesMenuOpen((o) => !o)}>
             <ListItemIcon>
@@ -157,12 +179,6 @@ function App() {
               </ListItemButton>
               <ListItemButton sx={{ pl: 4 }} onClick={() => go('principiosEspecificos')}>
                 <ListItemText primary="Principios específicos" />
-              </ListItemButton>
-              <ListItemButton sx={{ pl: 4 }} onClick={() => go('principiosGuardarrail')}>
-                <ListItemIcon>
-                  <span className="material-symbols-outlined">rule</span>
-                </ListItemIcon>
-                <ListItemText primary="Principios Guardarrail" />
               </ListItemButton>
             </List>
           </Collapse>


### PR DESCRIPTION
## Resumen
- Anida "Principios Guardarrail" dentro del menú "Programas Guardarrail" con un submenú inicial "Programas".
- Actualiza la documentación de casos de uso para reflejar la nueva jerarquía de menús.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a26b3c6e34833186ef9a250cdcfeb9