### PR TITLE
feat: manage strategic plan links for guardrail objectives

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -170,6 +170,43 @@ async function initDb() {
   );
 
   await pool.query(
+    `CREATE TABLE IF NOT EXISTS objetivos_guardarrail (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      programa_id INT NOT NULL,
+      codigo VARCHAR(255) NOT NULL,
+      titulo VARCHAR(255) NOT NULL,
+      descripcion TEXT NOT NULL,
+      FOREIGN KEY (programa_id) REFERENCES programas_guardarrail(id) ON DELETE CASCADE
+    )`
+  );
+  await pool.query(
+    "ALTER TABLE objetivos_guardarrail MODIFY COLUMN descripcion TEXT"
+  );
+
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS objetivo_guardarrail_planes (
+      objetivo_id INT NOT NULL,
+      plan_id INT NOT NULL,
+      PRIMARY KEY (objetivo_id, plan_id),
+      FOREIGN KEY (objetivo_id) REFERENCES objetivos_guardarrail(id) ON DELETE CASCADE,
+      FOREIGN KEY (plan_id) REFERENCES planes_estrategicos(id) ON DELETE CASCADE
+    )`
+  );
+
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS objetivos_guardarrail_evidencias (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      objetivo_id INT NOT NULL,
+      codigo VARCHAR(255) NOT NULL,
+      descripcion TEXT NOT NULL,
+      FOREIGN KEY (objetivo_id) REFERENCES objetivos_guardarrail(id) ON DELETE CASCADE
+    )`
+  );
+  await pool.query(
+    "ALTER TABLE objetivos_guardarrail_evidencias MODIFY COLUMN descripcion TEXT"
+  );
+
+  await pool.query(
 
     `CREATE TABLE IF NOT EXISTS objetivos_estrategicos (
       id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- track associated strategic plans for each guardrail objective in the database
- expose plan associations in guardrail objective API including cascade info on delete
- allow UI to edit, filter, display and export guardrail objectives by their plans

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75f9d242083318cb1903a3742ea27