### PR TITLE
Reordena submenús de planes estratégicos y actualiza casos de uso

### DIFF
--- a/docs/funcional/use-cases/planes-estrategicos/00 Menu Planes Estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/00 Menu Planes Estrategicos.md
@@ -1,0 +1,17 @@
+---
+title: "Casos de Uso - Menú Planes Estratégicos"
+domain: "Planes Estratégicos"
+version: "1.0"
+date: "2025-08-18"
+author: "DGSIC"
+---
+
+# Menú Planes Estratégicos
+
+El menú **Planes Estratégicos** organiza la gestión en tres submenús visibles en el siguiente orden:
+
+1. **Planes** – Administración de planes estratégicos.
+2. **Principios específicos** – Gestión de principios vinculados a los planes.
+3. **Objetivos estratégicos** – Definición de objetivos y sus evidencias.
+
+Cada submenú enlaza con los casos de uso descritos en los ficheros correspondientes.

--- a/docs/funcional/use-cases/planes-estrategicos/01 Planes estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/01 Planes estrategicos.md
@@ -10,6 +10,7 @@ author: "DGSIC"
 
 ## Contexto
 La aplicación permite gestionar Planes estratégicos vinculados a los PMTDE.
+En el menú "Planes estratégicos", el submenú "Planes" se muestra en primer lugar, seguido de "Principios específicos" y "Objetivos estratégicos".
 
 ---
 

--- a/docs/funcional/use-cases/planes-estrategicos/02 Principios especificos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/02 Principios especificos.md
@@ -10,6 +10,7 @@ author: "DGSIC"
 
 ## Contexto
 La aplicación permite gestionar principios específicos vinculados a los planes estratégicos.
+Dentro del menú "Planes estratégicos", el submenú "Principios específicos" se muestra en segundo lugar, precedido por "Planes" y seguido de "Objetivos estratégicos".
 
 ---
 

--- a/docs/funcional/use-cases/planes-estrategicos/03 Objetivos Estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/03 Objetivos Estrategicos.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: Gestión de Objetivos Estratégicos
 
 ## Contexto
-Se requiere la creación de un submenú "Objetivos estratégicos" dentro del menú de "Planes Estratégicos".  
+El submenú "Objetivos estratégicos" forma parte del menú "Planes estratégicos" y se ubica en tercer lugar, después de "Planes" y "Principios específicos".
 Cada **objetivo estratégico** está vinculado obligatoriamente a un **plan estratégico** y podrá contener **evidencias** asociadas.
 
 ---

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -186,17 +186,17 @@ function App() {
                 </ListItemIcon>
                 <ListItemText primary="Planes" />
               </ListItemButton>
-              <ListItemButton sx={{ pl: 4 }} onClick={() => go('objetivosEstrategicos')}>
-                <ListItemIcon>
-                  <span className="material-symbols-outlined">my_location</span>
-                </ListItemIcon>
-                <ListItemText primary="Objetivos estratégicos" />
-              </ListItemButton>
               <ListItemButton sx={{ pl: 4 }} onClick={() => go('principiosEspecificos')}>
                 <ListItemIcon>
                   <span className="material-symbols-outlined">fact_check</span>
                 </ListItemIcon>
                 <ListItemText primary="Principios específicos" />
+              </ListItemButton>
+              <ListItemButton sx={{ pl: 4 }} onClick={() => go('objetivosEstrategicos')}>
+                <ListItemIcon>
+                  <span className="material-symbols-outlined">my_location</span>
+                </ListItemIcon>
+                <ListItemText primary="Objetivos estratégicos" />
               </ListItemButton>
             </List>
           </Collapse>


### PR DESCRIPTION
## Summary
- Reordena los submenús de "Planes Estratégicos" para mostrar Planes, Principios específicos y Objetivos estratégicos
- Actualiza los casos de uso para reflejar el nuevo orden y añade documentación del menú

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a77d31ad68833197ac9c1a073bcdef