### PR TITLE
feat: add guardrail traceability matrix

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -207,6 +207,28 @@ async function initDb() {
   );
 
   await pool.query(
+    'RENAME TABLE principio_objetivo_trazabilidad TO principioGR_objetivoGR_trazabilidad'
+  ).catch(() => {});
+  await pool.query(
+    'ALTER TABLE principioGR_objetivoGR_trazabilidad CHANGE COLUMN principio_id principioGR_id INT NOT NULL'
+  ).catch(() => {});
+  await pool.query(
+    'ALTER TABLE principioGR_objetivoGR_trazabilidad CHANGE COLUMN objetivo_id objetivoGR_id INT NOT NULL'
+  ).catch(() => {});
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS principioGR_objetivoGR_trazabilidad (
+      programa_id INT NOT NULL,
+      principioGR_id INT NOT NULL,
+      objetivoGR_id INT NOT NULL,
+      nivel INT NOT NULL,
+      PRIMARY KEY (programa_id, principioGR_id, objetivoGR_id),
+      FOREIGN KEY (programa_id) REFERENCES programas_guardarrail(id) ON DELETE CASCADE,
+      FOREIGN KEY (principioGR_id) REFERENCES principios_guardarrail(id) ON DELETE CASCADE,
+      FOREIGN KEY (objetivoGR_id) REFERENCES objetivos_guardarrail(id) ON DELETE CASCADE
+    )`
+  );
+
+  await pool.query(
 
     `CREATE TABLE IF NOT EXISTS objetivos_estrategicos (
       id INT AUTO_INCREMENT PRIMARY KEY,

--- a/backend/routes/trazabilidadPrincipiosGRObjetivosGR.js
+++ b/backend/routes/trazabilidadPrincipiosGRObjetivosGR.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const { getDb } = require('../db');
+
+const router = express.Router();
+
+router.get('/:programaId', async (req, res) => {
+  const pool = getDb();
+  const programaId = parseInt(req.params.programaId, 10) || 1;
+  const [principiosGR] = await pool.query(
+    'SELECT id, codigo, titulo FROM principios_guardarrail WHERE programa_id=?',
+    [programaId]
+  );
+  const [objetivosGR] = await pool.query(
+    'SELECT id, codigo, titulo FROM objetivos_guardarrail WHERE programa_id=?',
+    [programaId]
+  );
+  const [relaciones] = await pool.query(
+    'SELECT principioGR_id, objetivoGR_id, nivel FROM principioGR_objetivoGR_trazabilidad WHERE programa_id=?',
+    [programaId]
+  );
+  res.json({ principiosGR, objetivosGR, relaciones });
+});
+
+router.post('/', async (req, res) => {
+  const pool = getDb();
+  const programaId = req.body.programaId || 1;
+  const principioGRId = req.body.principioGRId || 1;
+  const objetivoGRId = req.body.objetivoGRId || 1;
+  const nivel = req.body.nivel != null ? req.body.nivel : 0;
+  await pool.query(
+    `INSERT INTO principioGR_objetivoGR_trazabilidad (programa_id, principioGR_id, objetivoGR_id, nivel)
+     VALUES (?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE nivel=VALUES(nivel)`,
+    [programaId, principioGRId, objetivoGRId, nivel]
+  );
+  res.json({ programaId, principioGRId, objetivoGRId, nivel });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,7 @@ const objetivosEstrategicosRouter = require('./routes/objetivosEstrategicos');
 const objetivosEstrategicosEvidenciasRouter = require('./routes/objetivosEstrategicosEvidencias');
 const objetivosGuardarrailRouter = require('./routes/objetivosGuardarrail');
 const objetivosGuardarrailEvidenciasRouter = require('./routes/objetivosGuardarrailEvidencias');
+const trazabilidadRouter = require('./routes/trazabilidadPrincipiosGRObjetivosGR');
 
 const preferenciasRouter = require('./routes/preferencias');
 
@@ -54,6 +55,7 @@ app.use('/api/objetivosEstrategicos', objetivosEstrategicosRouter);
 app.use('/api/objetivosEstrategicosEvidencias', objetivosEstrategicosEvidenciasRouter);
 app.use('/api/objetivosGuardarrail', objetivosGuardarrailRouter);
 app.use('/api/objetivosGuardarrailEvidencias', objetivosGuardarrailEvidenciasRouter);
+app.use('/api/trazabilidad', trazabilidadRouter);
 
 app.use('/api/principiosEspecificos', principiosRouter);
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,6 +36,7 @@
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosEstrategicosEvidenciasApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailEvidenciasApi.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/TrazabilidadPrincipioGRObjetivoGRApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PrincipiosEspecificosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ParametrosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ImportExportApi.js"></script>
@@ -54,6 +55,7 @@
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailEvidenciasManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PrincipiosEspecificosManager.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/TrazabilidadPrincipioGRObjetivoGRManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ParametrosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ImportExportManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/AdminPanel.js"></script>

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -166,6 +166,12 @@ function App() {
                 </ListItemIcon>
                 <ListItemText primary="Objetivos Guardarrail" />
               </ListItemButton>
+              <ListItemButton sx={{ pl: 4 }} onClick={() => go('trazabilidad')}>
+                <ListItemIcon>
+                  <span className="material-symbols-outlined">grid_on</span>
+                </ListItemIcon>
+                <ListItemText primary="Trazabilidad principios GR vs objetivos GR" />
+              </ListItemButton>
             </List>
           </Collapse>
 
@@ -236,6 +242,9 @@ function App() {
           />
         )}
         {view === 'objetivosGuardarrail' && <ObjetivosGuardarrailManager />}
+        {view === 'trazabilidad' && (
+          <TrazabilidadPrincipioGRObjetivoGRManager programasGuardarrail={programasGuardarrail} />
+        )}
         {view === 'planesEstrategicos' && (
           <PlanesEstrategicosManager usuarios={usuarios} pmtde={pmtde} />
         )}

--- a/frontend/js/TrazabilidadPrincipioGRObjetivoGRApi.js
+++ b/frontend/js/TrazabilidadPrincipioGRObjetivoGRApi.js
@@ -1,0 +1,14 @@
+const trazabilidadGRApi = {
+  get: async (programaId) => {
+    const res = await fetch(`/api/trazabilidad/${programaId}`);
+    return res.json();
+  },
+  save: async ({ programaId, principioGRId, objetivoGRId, nivel }) => {
+    const res = await fetch('/api/trazabilidad', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ programaId, principioGRId, objetivoGRId, nivel }),
+    });
+    return res.json();
+  },
+};

--- a/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
+++ b/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
@@ -1,0 +1,205 @@
+function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
+  const [programa, setPrograma] = React.useState(null);
+  const [principiosGR, setPrincipiosGR] = React.useState([]);
+  const [objetivosGR, setObjetivosGR] = React.useState([]);
+  const [relaciones, setRelaciones] = React.useState({});
+  const [editing, setEditing] = React.useState(null);
+  const [snack, setSnack] = React.useState(false);
+  const { busy, seconds, perform } = useProcessing();
+
+  const load = async (progId) => {
+    const data = await trazabilidadGRApi.get(progId);
+    setPrincipiosGR(data.principiosGR);
+    setObjetivosGR(data.objetivosGR);
+    const map = {};
+    (data.relaciones || []).forEach((r) => {
+      map[`${r.principioGR_id}-${r.objetivoGR_id}`] = r.nivel;
+    });
+    setRelaciones(map);
+  };
+
+  const handleProgramChange = (val) => {
+    setPrograma(val);
+    if (val) load(val.id);
+  };
+
+  const handleCellClick = (objGRId, prinGRId) => {
+    if (busy) return;
+    const key = `${prinGRId}-${objGRId}`;
+    const value = relaciones[key] != null ? relaciones[key] : 0;
+    setEditing({ objGRId, prinGRId, value });
+  };
+
+  const handleLevelChange = async (value) => {
+    const { objGRId, prinGRId } = editing;
+    await perform(async () => {
+      await trazabilidadGRApi.save({
+        programaId: programa.id,
+        objetivoGRId: objGRId,
+        principioGRId: prinGRId,
+        nivel: value,
+      });
+      await load(programa.id);
+      setSnack(true);
+    });
+    setEditing(null);
+  };
+
+  const renderCell = (objGRId, prinGRId) => {
+    const key = `${prinGRId}-${objGRId}`;
+    const nivel = relaciones[key];
+    if (editing && editing.objGRId === objGRId && editing.prinGRId === prinGRId) {
+      return (
+        <Select
+          value={editing.value}
+          open
+          onChange={(e) => handleLevelChange(parseInt(e.target.value, 10))}
+          onClose={() => setEditing(null)}
+          disabled={busy}
+          autoWidth
+        >
+          <MenuItem value={0}>N/A</MenuItem>
+          <MenuItem value={1}>Baja</MenuItem>
+          <MenuItem value={2}>Media</MenuItem>
+          <MenuItem value={3}>Alta</MenuItem>
+        </Select>
+      );
+    }
+    if (nivel == null) {
+      return (
+        <span className="material-symbols-outlined" style={{ color: 'red' }}>
+          block
+        </span>
+      );
+    }
+    if (nivel === 0) return 'N/A';
+    const colors = ['#a5d6a7', '#66bb6a', '#2e7d32'];
+    return (
+      <span>
+        {Array.from({ length: nivel }).map((_, i) => (
+          <span
+            key={i}
+            className="material-symbols-outlined"
+            style={{ color: colors[i] }}
+          >
+            fiber_manual_record
+          </span>
+        ))}
+      </span>
+    );
+  };
+
+  const exportCSV = () => {
+    if (!programa) return;
+    const headers = ['Objetivo \\ Principio', ...principiosGR.map((p) => p.codigo)];
+    const rows = objetivosGR.map((o) => {
+      const row = [o.codigo];
+      principiosGR.forEach((p) => {
+        const key = `${p.id}-${o.id}`;
+        const nivel = relaciones[key];
+        if (nivel == null) row.push('Sin relación');
+        else if (nivel === 0) row.push('N/A');
+        else if (nivel === 1) row.push('Baja');
+        else if (nivel === 2) row.push('Media');
+        else row.push('Alta');
+      });
+      return row;
+    });
+    exportToCSV(headers, rows, 'TrazabilidadPrincipiosGRObjetivosGR');
+  };
+
+  const exportPDF = () => {
+    if (!programa) return;
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text('Trazabilidad principios GR vs objetivos GR', 10, 10);
+    let y = 20;
+    const header = ['Objetivo', ...principiosGR.map((p) => p.codigo)].join(' | ');
+    doc.text(header, 10, y);
+    y += 10;
+    objetivosGR.forEach((o) => {
+      const vals = [o.codigo];
+      principiosGR.forEach((p) => {
+        const key = `${p.id}-${o.id}`;
+        const nivel = relaciones[key];
+        if (nivel == null) vals.push('Sin relación');
+        else if (nivel === 0) vals.push('N/A');
+        else if (nivel === 1) vals.push('Baja');
+        else if (nivel === 2) vals.push('Media');
+        else vals.push('Alta');
+      });
+      doc.text(vals.join(' | '), 10, y);
+      y += 10;
+      if (y > 280) {
+        doc.addPage();
+        y = 10;
+      }
+    });
+    doc.save(`${formatDate()} TrazabilidadPrincipiosGRObjetivosGR.pdf`);
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Trazabilidad principios GR vs objetivos GR
+      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Autocomplete
+          options={programasGuardarrail}
+          getOptionLabel={(p) => p.nombre}
+          value={programa}
+          onChange={(e, val) => handleProgramChange(val)}
+          renderInput={(params) => (
+            <TextField {...params} label="Programa guardarrail*" />
+          )}
+          sx={{ minWidth: 300 }}
+        />
+        <Tooltip title="Exportar CSV">
+          <IconButton onClick={exportCSV} disabled={!programa || busy}>
+            <span className="material-symbols-outlined">download</span>
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <IconButton onClick={exportPDF} disabled={!programa || busy}>
+            <span className="material-symbols-outlined">picture_as_pdf</span>
+          </IconButton>
+        </Tooltip>
+      </Box>
+      {programa && (
+        <Table>
+          <TableHead sx={tableHeadSx}>
+            <TableRow>
+              <TableCell>Objetivo \\ Principio</TableCell>
+              {principiosGR.map((p) => (
+                <TableCell key={p.id}>{p.codigo}</TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {objetivosGR.map((o) => (
+              <TableRow key={o.id}>
+                <TableCell>{o.codigo}</TableCell>
+                {principiosGR.map((p) => (
+                  <TableCell
+                    key={p.id}
+                    onClick={() => handleCellClick(o.id, p.id)}
+                    sx={{ cursor: 'pointer' }}
+                  >
+                    {renderCell(o.id, p.id)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+      <ProcessingBanner seconds={seconds} />
+      <Snackbar
+        open={snack}
+        autoHideDuration={3000}
+        onClose={() => setSnack(false)}
+        message="Nivel actualizado"
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- create table and API for principle-objective traceability levels
- add traceability matrix UI with update and export options
- expose new menu for guardrail traceability
- rename traceability table and fields to use GR-specific names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77d9eff508331b69f6c4fb8314120