### PR TITLE
fix: define Snackbar component

### DIFF
--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -33,6 +33,7 @@ const {
   MenuItem,
   Checkbox,
   FormControlLabel,
+  Snackbar,
 } = MaterialUI;
 
 const formatDate = () => {


### PR DESCRIPTION
## Summary
- include `Snackbar` from Material UI globals to prevent runtime ReferenceError

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a781dd24e083318cefb447fbe11f8a