### PR TITLE
Handle cascade warnings on delete actions

### DIFF
--- a/frontend/js/ObjetivosEstrategicosApi.js
+++ b/frontend/js/ObjetivosEstrategicosApi.js
@@ -16,7 +16,13 @@ const objetivosEstrategicosApi = {
     if (!res.ok) throw new Error('Error al guardar objetivo estratégico');
     return res.json();
   },
-  remove: async (id) => {
-    await fetch(`/api/objetivosEstrategicos/${id}?confirm=true`, { method: 'DELETE' });
+  remove: async (id, confirm = false) => {
+    const url = `/api/objetivosEstrategicos/${id}` + (confirm ? '?confirm=true' : '');
+    const res = await fetch(url, { method: 'DELETE' });
+    if (res.status === 400) {
+      const data = await res.json();
+      return { status: res.status, ...data };
+    }
+    return { status: res.status };
   },
 };

--- a/frontend/js/ObjetivosEstrategicosManager.js
+++ b/frontend/js/ObjetivosEstrategicosManager.js
@@ -56,10 +56,16 @@ function ObjetivosEstrategicosManager() {
   };
 
   const handleDelete = (id) => {
-    if (!window.confirm('¿Eliminar objetivo y sus evidencias? Esta acción es irreversible.'))
-      return;
     perform(async () => {
-      await objetivosEstrategicosApi.remove(id);
+      const res = await objetivosEstrategicosApi.remove(id);
+      if (res.status === 400 && res.cascades) {
+        const cascadesMsg = Object.entries(res.cascades)
+          .map(([k, v]) => `${v} ${k}`)
+          .join(', ');
+        const msg = `¿Eliminar objetivo y sus evidencias? Se eliminarán también: ${cascadesMsg}. Esta acción es irreversible.`;
+        if (!window.confirm(msg)) return;
+        await objetivosEstrategicosApi.remove(id, true);
+      }
       const list = await objetivosEstrategicosApi.list();
       setObjetivos(list);
     });

--- a/frontend/js/ObjetivosGuardarrailApi.js
+++ b/frontend/js/ObjetivosGuardarrailApi.js
@@ -15,7 +15,13 @@ const objetivosGuardarrailApi = {
     });
     return res.json();
   },
-  remove: async (id) => {
-    await fetch(`/api/objetivosGuardarrail/${id}?confirm=true`, { method: 'DELETE' });
+  remove: async (id, confirm = false) => {
+    const url = `/api/objetivosGuardarrail/${id}` + (confirm ? '?confirm=true' : '');
+    const res = await fetch(url, { method: 'DELETE' });
+    if (res.status === 400) {
+      const data = await res.json();
+      return { status: res.status, ...data };
+    }
+    return { status: res.status };
   },
 };

--- a/frontend/js/ObjetivosGuardarrailManager.js
+++ b/frontend/js/ObjetivosGuardarrailManager.js
@@ -75,9 +75,16 @@ function ObjetivosGuardarrailManager() {
   };
 
   const handleDelete = (id) => {
-    if (!window.confirm('¿Eliminar objetivo y sus evidencias? Esta acción es irreversible.')) return;
     perform(async () => {
-      await objetivosGuardarrailApi.remove(id);
+      const res = await objetivosGuardarrailApi.remove(id);
+      if (res.status === 400 && res.cascades) {
+        const cascadesMsg = Object.entries(res.cascades)
+          .map(([k, v]) => `${v} ${k}`)
+          .join(', ');
+        const msg = `¿Eliminar objetivo y sus evidencias? Se eliminarán también: ${cascadesMsg}. Esta acción es irreversible.`;
+        if (!window.confirm(msg)) return;
+        await objetivosGuardarrailApi.remove(id, true);
+      }
       const list = await objetivosGuardarrailApi.list();
       setObjetivos(list);
     });

--- a/frontend/js/PlanesEstrategicosApi.js
+++ b/frontend/js/PlanesEstrategicosApi.js
@@ -17,7 +17,13 @@ const planesEstrategicosApi = {
     });
     return res.json();
   },
-  remove: async (id) => {
-    await fetch(`/api/planesEstrategicos/${id}?confirm=true`, { method: 'DELETE' });
+  remove: async (id, confirm = false) => {
+    const url = `/api/planesEstrategicos/${id}` + (confirm ? '?confirm=true' : '');
+    const res = await fetch(url, { method: 'DELETE' });
+    if (res.status === 400) {
+      const data = await res.json();
+      return { status: res.status, ...data };
+    }
+    return { status: res.status };
   },
 };

--- a/frontend/js/PlanesEstrategicosManager.js
+++ b/frontend/js/PlanesEstrategicosManager.js
@@ -68,9 +68,16 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
   };
 
   const handleDelete = (id) => {
-    if (!window.confirm('¿Eliminar plan estratégico y sus expertos asociados? Esta acción es irreversible.')) return;
     perform(async () => {
-      await planesEstrategicosApi.remove(id);
+      const res = await planesEstrategicosApi.remove(id);
+      if (res.status === 400 && res.cascades) {
+        const cascadesMsg = Object.entries(res.cascades)
+          .map(([k, v]) => `${v} ${k}`)
+          .join(', ');
+        const msg = `¿Eliminar plan estratégico y sus expertos asociados? Se eliminarán también: ${cascadesMsg}. Esta acción es irreversible.`;
+        if (!window.confirm(msg)) return;
+        await planesEstrategicosApi.remove(id, true);
+      }
       const list = await planesEstrategicosApi.list();
       setPlanesEstrategicos(list);
     });

--- a/frontend/js/ProgramaGuardarrailApi.js
+++ b/frontend/js/ProgramaGuardarrailApi.js
@@ -14,7 +14,13 @@ const programasGuardarrailApi = {
     });
     return res.json();
   },
-  remove: async (id) => {
-    await fetch(`/api/programasGuardarrail/${id}?confirm=true`, { method: 'DELETE' });
+  remove: async (id, confirm = false) => {
+    const url = `/api/programasGuardarrail/${id}` + (confirm ? '?confirm=true' : '');
+    const res = await fetch(url, { method: 'DELETE' });
+    if (res.status === 400) {
+      const data = await res.json();
+      return { status: res.status, ...data };
+    }
+    return { status: res.status };
   },
 };

--- a/frontend/js/ProgramaGuardarrailManager.js
+++ b/frontend/js/ProgramaGuardarrailManager.js
@@ -56,9 +56,16 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
   };
 
   const handleDelete = (id) => {
-    if (!window.confirm('¿Eliminar programa guardarrail y sus expertos asociados? Esta acción es irreversible.')) return;
     perform(async () => {
-      await programasGuardarrailApi.remove(id);
+      const res = await programasGuardarrailApi.remove(id);
+      if (res.status === 400 && res.cascades) {
+        const cascadesMsg = Object.entries(res.cascades)
+          .map(([k, v]) => `${v} ${k}`)
+          .join(', ');
+        const msg = `¿Eliminar programa guardarrail y sus expertos asociados? Se eliminarán también: ${cascadesMsg}. Esta acción es irreversible.`;
+        if (!window.confirm(msg)) return;
+        await programasGuardarrailApi.remove(id, true);
+      }
       const list = await programasGuardarrailApi.list();
       setProgramasGuardarrail(list);
       if (refreshPrincipios) await refreshPrincipios();


### PR DESCRIPTION
## Summary
- Defer deletion confirmation until after an initial DELETE call without `confirm=true`
- Surface related record counts from backend in confirmation prompts before final deletion
- Allow API clients to attempt deletes without confirmation and handle 400 cascade responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a782cf1ea48331a7ed87df86ed7b4c