### PR TITLE
fix: wrap disabled buttons with span in tooltips

### DIFF
--- a/frontend/js/ListActions.js
+++ b/frontend/js/ListActions.js
@@ -2,34 +2,46 @@ function ListActions({ onCreate, onToggleFilter, onOpenColumns, view, onToggleVi
   return (
     <Box sx={{ display: 'flex', gap: 1, mb: 1, ...(sx || {}) }}>
       <Tooltip title="Añadir">
-        <IconButton onClick={onCreate} disabled={busy}>
-          <span className="material-symbols-outlined">add</span>
-        </IconButton>
+        <span>
+          <IconButton onClick={onCreate} disabled={busy}>
+            <span className="material-symbols-outlined">add</span>
+          </IconButton>
+        </span>
       </Tooltip>
       <Tooltip title="Filtrar">
-        <IconButton onClick={onToggleFilter} disabled={busy}>
-          <span className="material-symbols-outlined">filter_list</span>
-        </IconButton>
+        <span>
+          <IconButton onClick={onToggleFilter} disabled={busy}>
+            <span className="material-symbols-outlined">filter_list</span>
+          </IconButton>
+        </span>
       </Tooltip>
       <Tooltip title="Seleccionar columnas">
-        <IconButton onClick={onOpenColumns} disabled={busy}>
-          <span className="material-symbols-outlined">view_column</span>
-        </IconButton>
+        <span>
+          <IconButton onClick={onOpenColumns} disabled={busy}>
+            <span className="material-symbols-outlined">view_column</span>
+          </IconButton>
+        </span>
       </Tooltip>
       <Tooltip title={view === 'table' ? 'Ver como cards' : 'Ver como tabla'}>
-        <IconButton onClick={onToggleView} disabled={busy}>
-          <span className="material-symbols-outlined">{view === 'table' ? 'dashboard' : 'table_rows'}</span>
-        </IconButton>
+        <span>
+          <IconButton onClick={onToggleView} disabled={busy}>
+            <span className="material-symbols-outlined">{view === 'table' ? 'dashboard' : 'table_rows'}</span>
+          </IconButton>
+        </span>
       </Tooltip>
       <Tooltip title="Exportar CSV">
-        <IconButton onClick={onExportCSV} disabled={busy}>
-          <span className="material-symbols-outlined">download</span>
-        </IconButton>
+        <span>
+          <IconButton onClick={onExportCSV} disabled={busy}>
+            <span className="material-symbols-outlined">download</span>
+          </IconButton>
+        </span>
       </Tooltip>
       <Tooltip title="Exportar PDF">
-        <IconButton onClick={onExportPDF} disabled={busy}>
-          <span className="material-symbols-outlined">picture_as_pdf</span>
-        </IconButton>
+        <span>
+          <IconButton onClick={onExportPDF} disabled={busy}>
+            <span className="material-symbols-outlined">picture_as_pdf</span>
+          </IconButton>
+        </span>
       </Tooltip>
     </Box>
   );

--- a/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
+++ b/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
@@ -155,14 +155,18 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
           sx={{ minWidth: 300 }}
         />
         <Tooltip title="Exportar CSV">
-          <IconButton onClick={exportCSV} disabled={!programa || busy}>
-            <span className="material-symbols-outlined">download</span>
-          </IconButton>
+          <span>
+            <IconButton onClick={exportCSV} disabled={!programa || busy}>
+              <span className="material-symbols-outlined">download</span>
+            </IconButton>
+          </span>
         </Tooltip>
         <Tooltip title="Exportar PDF">
-          <IconButton onClick={exportPDF} disabled={!programa || busy}>
-            <span className="material-symbols-outlined">picture_as_pdf</span>
-          </IconButton>
+          <span>
+            <IconButton onClick={exportPDF} disabled={!programa || busy}>
+              <span className="material-symbols-outlined">picture_as_pdf</span>
+            </IconButton>
+          </span>
         </Tooltip>
       </Box>
       {programa && (


### PR DESCRIPTION
## Summary
- wrap disabled export buttons with span in TrazabilidadPrincipioGRObjetivoGRManager to satisfy MUI Tooltip requirements
- wrap all action buttons in ListActions with span to prevent tooltip warnings when disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a783e2f3408331b57405a7dead6adf