### PR TITLE
feat: toggle label view in GR traceability matrix

### DIFF
--- a/backend/routes/trazabilidadPrincipiosGRObjetivosGR.js
+++ b/backend/routes/trazabilidadPrincipiosGRObjetivosGR.js
@@ -7,11 +7,11 @@ router.get('/:programaId', async (req, res) => {
   const pool = getDb();
   const programaId = parseInt(req.params.programaId, 10) || 1;
   const [principiosGR] = await pool.query(
-    'SELECT id, codigo, titulo FROM principios_guardarrail WHERE programa_id=?',
+    'SELECT id, codigo, titulo, descripcion FROM principios_guardarrail WHERE programa_id=?',
     [programaId]
   );
   const [objetivosGR] = await pool.query(
-    'SELECT id, codigo, titulo FROM objetivos_guardarrail WHERE programa_id=?',
+    'SELECT id, codigo, titulo, descripcion FROM objetivos_guardarrail WHERE programa_id=?',
     [programaId]
   );
   const [relaciones] = await pool.query(

--- a/docs/funcional/use-cases/programas-guardarrailes/04 Trazabilidad Principios Guardarrail vs Objetivos Guardarrail.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/04 Trazabilidad Principios Guardarrail vs Objetivos Guardarrail.md
@@ -1,7 +1,7 @@
 ---
 title: "Casos de Uso - Trazabilidad Principios Guardarrail vs Objetivos Guardarrail"
 domain: "Programas guardarrailes"
-version: "1.0"
+version: "1.1"
 date: "2025-08-21"
 author: "DGSIC"
 ---
@@ -25,7 +25,8 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 2. El sistema muestra una tabla de doble entrada en la que:
    - Las columnas corresponden a los principios guardarrail.
    - Las filas representan los objetivos guardarrail.
-   - Al situar el cursor sobre el código de un principio u objetivo se muestra su nombre completo en un tooltip.
+   - El usuario puede elegir si visualizar únicamente los códigos o el formato "código - título" tanto en filas como en columnas.
+   - Al situar el cursor sobre un principio u objetivo se muestra un tooltip con el título en negrita y, en líneas sucesivas, su descripción.
    - En cada celda se muestra el nivel de trazabilidad asociado entre principio y objetivo:
      - **0 – "Sin relación"**, mostrado como un circulo con el borde rojo y una ralla roja en diagonal**.
      - **1 – "Baja"**, representada por **un círculo verde claro**.

--- a/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
+++ b/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
@@ -5,6 +5,7 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
   const [relaciones, setRelaciones] = React.useState({});
   const [editing, setEditing] = React.useState(null);
   const [snack, setSnack] = React.useState(false);
+  const [displayMode, setDisplayMode] = React.useState('code');
   const { busy, seconds, perform } = useProcessing();
 
   const load = async (progId) => {
@@ -17,6 +18,18 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
     });
     setRelaciones(map);
   };
+
+  const formatLabel = (item) =>
+    displayMode === 'codeTitle' ? `${item.codigo} - ${item.titulo}` : item.codigo;
+
+  const tooltipContent = (titulo, descripcion) => (
+    <React.Fragment>
+      <Typography fontWeight="bold">{titulo}</Typography>
+      {descripcion && (
+        <Typography sx={{ whiteSpace: 'pre-line' }}>{descripcion}</Typography>
+      )}
+    </React.Fragment>
+  );
 
   const handleProgramChange = (val) => {
     setPrograma(val);
@@ -154,6 +167,18 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
           )}
           sx={{ minWidth: 300 }}
         />
+        <FormControl size="small" sx={{ minWidth: 180 }}>
+          <InputLabel id="display-mode-label">Formato</InputLabel>
+          <Select
+            labelId="display-mode-label"
+            value={displayMode}
+            label="Formato"
+            onChange={(e) => setDisplayMode(e.target.value)}
+          >
+            <MenuItem value="code">Solo códigos</MenuItem>
+            <MenuItem value="codeTitle">Código y título</MenuItem>
+          </Select>
+        </FormControl>
         <Tooltip title="Exportar CSV">
           <span>
             <IconButton onClick={exportCSV} disabled={!programa || busy}>
@@ -176,8 +201,8 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
               <TableCell>Objetivo \\ Principio</TableCell>
               {principiosGR.map((p) => (
                 <TableCell key={p.id}>
-                  <Tooltip title={p.titulo}>
-                    <span>{p.codigo}</span>
+                  <Tooltip title={tooltipContent(p.titulo, p.descripcion)}>
+                    <span>{formatLabel(p)}</span>
                   </Tooltip>
                 </TableCell>
               ))}
@@ -187,8 +212,8 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
             {objetivosGR.map((o) => (
               <TableRow key={o.id}>
                 <TableCell>
-                  <Tooltip title={o.titulo}>
-                    <span>{o.codigo}</span>
+                  <Tooltip title={tooltipContent(o.titulo, o.descripcion)}>
+                    <span>{formatLabel(o)}</span>
                   </Tooltip>
                 </TableCell>
                 {principiosGR.map((p) => (

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -33,6 +33,8 @@ const {
   MenuItem,
   Select,
   Checkbox,
+  FormControl,
+  InputLabel,
   FormControlLabel,
   Snackbar,
 } = MaterialUI;


### PR DESCRIPTION
## Summary
- add option to switch between code-only or code-title labels in GR traceability matrix
- enrich tooltips with bold titles and descriptions
- document new viewing options and tooltip behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78738957c8331a61b855cca08aa66