### PR TITLE
Permitir seleccionar sin relación en trazabilidad

### DIFF
--- a/docs/funcional/use-cases/programas-guardarrailes/04 Trazabilidad Principios Guardarrail vs Objetivos Guardarrail.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/04 Trazabilidad Principios Guardarrail vs Objetivos Guardarrail.md
@@ -27,7 +27,7 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
    - Las filas representan los objetivos guardarrail.
    - Al situar el cursor sobre el código de un principio u objetivo se muestra su nombre completo en un tooltip.
    - En cada celda se muestra el nivel de trazabilidad asociado entre principio y objetivo:
-     - **0 – "Sin relación"**, mostrado como un circulo con el borde rojo y una ralla roja en diagonal**.
+     - **0 – "Sin relación"**, representada por un guion **"-"**.
      - **1 – "Baja"**, representada por **un círculo verde claro**.
      - **2 – "Media"**, representada por **dos círculos verde medio**.
      - **3 – "Alta"**, representada por **tres círculos verde oscuro**.
@@ -48,10 +48,11 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 **Flujo principal:**
 1. El usuario selecciona una celda correspondiente a un principio y un objetivo.
 2. Se muestra un desplegable con los valores posibles:
-   - **0 – "No aplica"**, mostrado como texto **"N/A"**.
+   - **0 – "Sin relación"**, representada por un guion **"-"**.
    - **1 – "Baja"**, representada por **un círculo verde claro**.
    - **2 – "Media"**, representada por **dos círculos verde medio**.
    - **3 – "Alta"**, representada por **tres círculos verde oscuro**.
+   - **4 – "No aplica"**, mostrado como texto **"N/A"**.
 3. El usuario elige un valor. El control queda desactivado hasta completar la operación; si dura más de un segundo aparece el banner "Procesando... X seg".
 4. El sistema guarda automáticamente el nivel seleccionado, refresca la matriz y muestra un banner superior confirmando la actualización.
 
@@ -60,6 +61,6 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 
 **Reglas de negocio:**
 - Cada combinación principio–objetivo tiene un único nivel de trazabilidad.
-- El nivel por defecto es **0 (N/A)**.
+- El nivel por defecto es **0 (Sin relación)**.
 
 ---

--- a/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
+++ b/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
@@ -58,21 +58,16 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
           disabled={busy}
           autoWidth
         >
-          <MenuItem value={0}>N/A</MenuItem>
+          <MenuItem value={0}>Sin relación</MenuItem>
           <MenuItem value={1}>Baja</MenuItem>
           <MenuItem value={2}>Media</MenuItem>
           <MenuItem value={3}>Alta</MenuItem>
+          <MenuItem value={4}>N/A</MenuItem>
         </Select>
       );
     }
-    if (nivel == null) {
-      return (
-        <span className="material-symbols-outlined" style={{ color: 'red' }}>
-          block
-        </span>
-      );
-    }
-    if (nivel === 0) return 'N/A';
+    if (nivel == null || nivel === 0) return '-';
+    if (nivel === 4) return 'N/A';
     const colors = ['#a5d6a7', '#66bb6a', '#2e7d32'];
     return (
       <span>
@@ -97,11 +92,11 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
       principiosGR.forEach((p) => {
         const key = `${p.id}-${o.id}`;
         const nivel = relaciones[key];
-        if (nivel == null) row.push('Sin relación');
-        else if (nivel === 0) row.push('N/A');
+        if (nivel == null || nivel === 0) row.push('Sin relación');
         else if (nivel === 1) row.push('Baja');
         else if (nivel === 2) row.push('Media');
-        else row.push('Alta');
+        else if (nivel === 3) row.push('Alta');
+        else row.push('N/A');
       });
       return row;
     });
@@ -122,11 +117,11 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
       principiosGR.forEach((p) => {
         const key = `${p.id}-${o.id}`;
         const nivel = relaciones[key];
-        if (nivel == null) vals.push('Sin relación');
-        else if (nivel === 0) vals.push('N/A');
+        if (nivel == null || nivel === 0) vals.push('Sin relación');
         else if (nivel === 1) vals.push('Baja');
         else if (nivel === 2) vals.push('Media');
-        else vals.push('Alta');
+        else if (nivel === 3) vals.push('Alta');
+        else vals.push('N/A');
       });
       doc.text(vals.join(' | '), 10, y);
       y += 10;


### PR DESCRIPTION
## Summary
- Añade opción de nivel "Sin relación" y "No aplica" en la matriz de trazabilidad y muestra un guion para la ausencia de relación.
- Ajusta exportaciones CSV/PDF y visualización de celdas según nuevos niveles.
- Actualiza documentación de casos de uso de trazabilidad para reflejar los nuevos valores.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a787e81cc4833190b5e2a8ba027d20