### PR TITLE
Show code in traceability tooltips

### DIFF
--- a/docs/funcional/use-cases/programas-guardarrailes/04 Trazabilidad Principios Guardarrail vs Objetivos Guardarrail.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/04 Trazabilidad Principios Guardarrail vs Objetivos Guardarrail.md
@@ -26,7 +26,7 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
    - Las columnas corresponden a los principios guardarrail.
    - Las filas representan los objetivos guardarrail.
    - El usuario puede elegir si visualizar únicamente los códigos o el formato "código - título" tanto en filas como en columnas.
-   - Al situar el cursor sobre un principio u objetivo se muestra un tooltip con el título en negrita y, en líneas sucesivas, su descripción.
+   - Al situar el cursor sobre un principio u objetivo se muestra un tooltip cuya primera línea, en negrita, contiene el código y el título con el formato "código - nombre"; en líneas sucesivas se muestra su descripción.
    - En cada celda se muestra el nivel de trazabilidad asociado entre principio y objetivo:
      - **0 – "Sin relación"**, representada por un guion **"-"**.
      - **1 – "Baja"**, representada por **un círculo verde claro**.

--- a/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
+++ b/frontend/js/TrazabilidadPrincipioGRObjetivoGRManager.js
@@ -22,9 +22,9 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
   const formatLabel = (item) =>
     displayMode === 'codeTitle' ? `${item.codigo} - ${item.titulo}` : item.codigo;
 
-  const tooltipContent = (titulo, descripcion) => (
+  const tooltipContent = (codigo, titulo, descripcion) => (
     <React.Fragment>
-      <Typography fontWeight="bold">{titulo}</Typography>
+      <Typography fontWeight="bold">{`${codigo} - ${titulo}`}</Typography>
       {descripcion && (
         <Typography sx={{ whiteSpace: 'pre-line' }}>{descripcion}</Typography>
       )}
@@ -196,7 +196,7 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
               <TableCell>Objetivo \\ Principio</TableCell>
               {principiosGR.map((p) => (
                 <TableCell key={p.id}>
-                  <Tooltip title={tooltipContent(p.titulo, p.descripcion)}>
+                  <Tooltip title={tooltipContent(p.codigo, p.titulo, p.descripcion)}>
                     <span>{formatLabel(p)}</span>
                   </Tooltip>
                 </TableCell>
@@ -207,7 +207,7 @@ function TrazabilidadPrincipioGRObjetivoGRManager({ programasGuardarrail }) {
             {objetivosGR.map((o) => (
               <TableRow key={o.id}>
                 <TableCell>
-                  <Tooltip title={tooltipContent(o.titulo, o.descripcion)}>
+                  <Tooltip title={tooltipContent(o.codigo, o.titulo, o.descripcion)}>
                     <span>{formatLabel(o)}</span>
                   </Tooltip>
                 </TableCell>


### PR DESCRIPTION
## Summary
- display `codigo - titulo` in bold when hovering over guardrail principles and objectives in the traceability matrix
- document tooltip format for traceability use case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78b116ecc8331a1158322d425a609