### PR TITLE
Clarify guardrail objective deletion message

### DIFF
--- a/docs/funcional/use-cases/programas-guardarrailes/03 Objetivos Guardarrail.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/03 Objetivos Guardarrail.md
@@ -64,13 +64,13 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 
 **Flujo principal:**
 1. El usuario selecciona un objetivo y solicita su eliminación.
-2. El sistema solicita confirmación en un diálogo. Tras aceptar, el botón queda desactivado y se muestra el banner "Procesando... X seg" si el proceso supera un segundo.
-3. El sistema elimina el objetivo, sus evidencias y las asociaciones con planes estratégicos.
+2. El sistema solicita confirmación en un diálogo, indicando el número de evidencias que se eliminarán y las vinculaciones con planes que se desvincularán. Tras aceptar, el botón queda desactivado y se muestra el banner "Procesando... X seg" si el proceso supera un segundo.
+3. El sistema elimina el objetivo y sus evidencias, y desvincula los planes estratégicos asociados.
 4. Recalcula los códigos de los objetivos restantes del mismo programa guardarrail.
 5. La lista de objetivos se refresca.
 
 **Postcondiciones:**
-- El objetivo, sus evidencias y asociaciones desaparecen del sistema.
+- El objetivo y sus evidencias desaparecen del sistema y se eliminan las asociaciones con planes estratégicos (los planes permanecen).
 - Los códigos de los objetivos restantes se actualizan para mantener la secuencia.
 
 ---

--- a/frontend/js/ObjetivosGuardarrailManager.js
+++ b/frontend/js/ObjetivosGuardarrailManager.js
@@ -79,7 +79,11 @@ function ObjetivosGuardarrailManager() {
       const res = await objetivosGuardarrailApi.remove(id);
       if (res.status === 400 && res.cascades) {
         const cascadesMsg = Object.entries(res.cascades)
-          .map(([k, v]) => `${v} ${k}`)
+          .map(([k, v]) =>
+            k === 'planes'
+              ? `las vinculaciones con ${v} plan${v === 1 ? '' : 'es'}`
+              : `${v} ${k}`
+          )
           .join(', ');
         const msg = `¿Eliminar objetivo y sus evidencias? Se eliminarán también: ${cascadesMsg}. Esta acción es irreversible.`;
         if (!window.confirm(msg)) return;


### PR DESCRIPTION
## Summary
- fix deletion confirmation to specify plan link removals instead of deleting plans
- document updated guardrail objective deletion behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78e4e394c83318327bfd5c621886a