### PR TITLE
feat: add DAFO module for strategic plans

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -266,6 +266,20 @@ async function initDb() {
   );
 
   await pool.query(
+    `CREATE TABLE IF NOT EXISTS dafo_pe (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      plan_id INT NOT NULL,
+      tipo ENUM('D','A','F','O') NOT NULL,
+      titulo VARCHAR(255) NOT NULL,
+      descripcion TEXT,
+      FOREIGN KEY (plan_id) REFERENCES planes_estrategicos(id) ON DELETE CASCADE
+    )`
+  );
+  await pool.query(
+    "ALTER TABLE dafo_pe MODIFY COLUMN descripcion TEXT"
+  );
+
+  await pool.query(
     `CREATE TABLE IF NOT EXISTS preferencias_usuario (
       usuario VARCHAR(255) NOT NULL DEFAULT 'anónimo',
       tabla VARCHAR(255) NOT NULL,

--- a/backend/routes/dafoPlanesEstrategicos.js
+++ b/backend/routes/dafoPlanesEstrategicos.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const { getDb } = require('../db');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  const pool = getDb();
+  const [rows] = await pool.query('SELECT id, plan_id, tipo, titulo, descripcion FROM dafo_pe');
+  if (rows.length === 0) return res.json([]);
+  const planIds = Array.from(new Set(rows.map((r) => r.plan_id)));
+  const [planRows] = planIds.length
+    ? await pool.query('SELECT id, nombre FROM planes_estrategicos WHERE id IN (?)', [planIds])
+    : [[], []];
+  const planMap = {};
+  planRows.forEach((p) => {
+    planMap[p.id] = { id: p.id, nombre: p.nombre };
+  });
+  const result = rows.map((r) => ({
+    id: r.id,
+    plan: planMap[r.plan_id] || null,
+    tipo: r.tipo,
+    titulo: r.titulo,
+    descripcion: r.descripcion,
+  }));
+  res.json(result);
+});
+
+router.post('/', async (req, res) => {
+  const pool = getDb();
+  const planId = req.body.plan && req.body.plan.id ? req.body.plan.id : 1;
+  const tipo = req.body.tipo || 'n/a';
+  const titulo = req.body.titulo || 'n/a';
+  const descripcion = req.body.descripcion || 'n/a';
+  const [result] = await pool.query(
+    'INSERT INTO dafo_pe (plan_id, tipo, titulo, descripcion) VALUES (?, ?, ?, ?)',
+    [planId, tipo, titulo, descripcion]
+  );
+  const [[plan]] = await pool.query('SELECT id, nombre FROM planes_estrategicos WHERE id=?', [planId]);
+  res.json({ id: result.insertId, plan, tipo, titulo, descripcion });
+});
+
+router.put('/:id', async (req, res) => {
+  const pool = getDb();
+  const planId = req.body.plan && req.body.plan.id ? req.body.plan.id : 1;
+  const tipo = req.body.tipo || 'n/a';
+  const titulo = req.body.titulo || 'n/a';
+  const descripcion = req.body.descripcion || 'n/a';
+  await pool.query(
+    'UPDATE dafo_pe SET plan_id=?, tipo=?, titulo=?, descripcion=? WHERE id=?',
+    [planId, tipo, titulo, descripcion, req.params.id]
+  );
+  const [[plan]] = await pool.query('SELECT id, nombre FROM planes_estrategicos WHERE id=?', [planId]);
+  res.json({ id: parseInt(req.params.id, 10), plan, tipo, titulo, descripcion });
+});
+
+router.delete('/:id', async (req, res) => {
+  const pool = getDb();
+  if (req.query.confirm !== 'true') {
+    return res.status(400).json({ message: 'Confirmar eliminación', cascades: {} });
+  }
+  await pool.query('DELETE FROM dafo_pe WHERE id=?', [req.params.id]);
+  res.sendStatus(204);
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ const programasGuardarrailRouter = require('./routes/programasGuardarrail');
 const principiosGuardarrailRouter = require('./routes/principiosGuardarrail');
 const planesEstrategicosRouter = require('./routes/planesEstrategicos');
 const principiosRouter = require('./routes/principiosEspecificos');
+const dafoPlanesEstrategicosRouter = require('./routes/dafoPlanesEstrategicos');
 const parametrosRouter = require('./routes/parametros');
 const objetivosEstrategicosRouter = require('./routes/objetivosEstrategicos');
 const objetivosEstrategicosEvidenciasRouter = require('./routes/objetivosEstrategicosEvidencias');
@@ -51,6 +52,7 @@ app.use('/api/pmtde', pmtdeRouter);
 app.use('/api/programasGuardarrail', programasGuardarrailRouter);
 app.use('/api/principiosGuardarrail', principiosGuardarrailRouter);
 app.use('/api/planesEstrategicos', planesEstrategicosRouter);
+app.use('/api/dafoPlanesEstrategicos', dafoPlanesEstrategicosRouter);
 
 app.use('/api/objetivosEstrategicos', objetivosEstrategicosRouter);
 app.use('/api/objetivosEstrategicosEvidencias', objetivosEstrategicosEvidenciasRouter);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,7 @@
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PrincipioGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosApi.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/DafoPlanesEstrategicosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosEstrategicosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosEstrategicosEvidenciasApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailApi.js"></script>
@@ -53,6 +54,7 @@
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosEstrategicosEvidenciasManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosEstrategicosManager.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/DafoPlanesEstrategicosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailEvidenciasManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PrincipiosEspecificosManager.js"></script>

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -204,6 +204,12 @@ function App() {
                 </ListItemIcon>
                 <ListItemText primary="Objetivos estratégicos" />
               </ListItemButton>
+              <ListItemButton sx={{ pl: 4 }} onClick={() => go('dafoPlanesEstrategicos')}>
+                <ListItemIcon>
+                  <span className="material-symbols-outlined">category</span>
+                </ListItemIcon>
+                <ListItemText primary="DAFO" />
+              </ListItemButton>
             </List>
           </Collapse>
         </List>
@@ -250,6 +256,7 @@ function App() {
         )}
         {view === 'objetivosEstrategicos' && <ObjetivosEstrategicosManager />}
         {view === 'principiosEspecificos' && <PrincipiosEspecificosManager />}
+        {view === 'dafoPlanesEstrategicos' && <DafoPlanesEstrategicosManager />}
         {view === 'admin' && (
           <AdminPanel
             usuarios={usuarios}

--- a/frontend/js/DafoPlanesEstrategicosApi.js
+++ b/frontend/js/DafoPlanesEstrategicosApi.js
@@ -1,0 +1,21 @@
+const dafoPlanesEstrategicosApi = {
+  list: async () => {
+    const res = await fetch('/api/dafoPlanesEstrategicos');
+    return res.json();
+  },
+  save: async (record) => {
+    const method = record.id ? 'PUT' : 'POST';
+    const url = record.id
+      ? `/api/dafoPlanesEstrategicos/${record.id}`
+      : '/api/dafoPlanesEstrategicos';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(record),
+    });
+    return res.json();
+  },
+  remove: async (id) => {
+    await fetch(`/api/dafoPlanesEstrategicos/${id}?confirm=true`, { method: 'DELETE' });
+  },
+};

--- a/frontend/js/DafoPlanesEstrategicosManager.js
+++ b/frontend/js/DafoPlanesEstrategicosManager.js
@@ -1,0 +1,267 @@
+function DafoPlanesEstrategicosManager() {
+  const tipos = ['Debilidad', 'Amenaza', 'Fortaleza', 'Oportunidad'];
+  const empty = { plan: null, tipo: '', titulo: '', descripcion: '' };
+  const columnsConfig = [
+    { key: 'plan', label: 'Plan estratégico', render: (d) => (d.plan ? d.plan.nombre : '') },
+    { key: 'tipo', label: 'Tipo', render: (d) => d.tipo },
+    { key: 'titulo', label: 'Título', render: (d) => d.titulo },
+    {
+      key: 'descripcion',
+      label: 'Descripción',
+      render: (d) => (
+        <span dangerouslySetInnerHTML={{ __html: marked.parse(d.descripcion || '') }} />
+      ),
+    },
+  ];
+  const { columns, openSelector, selector } = useColumnPreferences('dafo_planes_estrategicos', columnsConfig);
+  const [registros, setRegistros] = React.useState([]);
+  const [planes, setPlanes] = React.useState([]);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [current, setCurrent] = React.useState(empty);
+  const [view, setView] = React.useState('table');
+  const [filterOpen, setFilterOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+  const [planFilter, setPlanFilter] = React.useState([]);
+  const [tipoFilter, setTipoFilter] = React.useState([]);
+  const [sortField, setSortField] = React.useState('titulo');
+  const [sortDir, setSortDir] = React.useState('asc');
+  const { busy, seconds, perform } = useProcessing();
+
+  React.useEffect(() => {
+    dafoPlanesEstrategicosApi.list().then(setRegistros);
+    planesEstrategicosApi.list().then(setPlanes);
+  }, []);
+
+  const openNew = () => {
+    setCurrent(empty);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (r) => {
+    setCurrent(r);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    await perform(async () => {
+      await dafoPlanesEstrategicosApi.save(current);
+      const list = await dafoPlanesEstrategicosApi.list();
+      setRegistros(list);
+      setDialogOpen(false);
+    });
+  };
+
+  const handleDelete = (id) => {
+    if (!window.confirm('¿Eliminar registro DAFO? Esta acción es irreversible.')) return;
+    perform(async () => {
+      await dafoPlanesEstrategicosApi.remove(id);
+      const list = await dafoPlanesEstrategicosApi.list();
+      setRegistros(list);
+    });
+  };
+
+  const filtered = registros
+    .filter((r) => {
+      const txt = normalize(
+        `${r.titulo} ${r.descripcion || ''} ${r.tipo} ${r.plan ? r.plan.nombre : ''}`
+      );
+      const searchMatch = txt.includes(normalize(search));
+      const planMatch = planFilter.length
+        ? planFilter.some((pf) => r.plan && pf.id === r.plan.id)
+        : true;
+      const tipoMatch = tipoFilter.length ? tipoFilter.includes(r.tipo) : true;
+      return searchMatch && planMatch && tipoMatch;
+    })
+    .sort((a, b) => {
+      const getVal = (obj) => {
+        if (sortField === 'plan') return normalize(obj.plan ? obj.plan.nombre : '');
+        return normalize(obj[sortField] || '');
+      };
+      const valA = getVal(a);
+      const valB = getVal(b);
+      if (valA < valB) return sortDir === 'asc' ? -1 : 1;
+      if (valA > valB) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+
+  const exportCSV = () => {
+    const header = ['Plan', 'Tipo', 'Título', 'Descripción'];
+    const rows = filtered.map((r) => [
+      r.plan ? r.plan.nombre : '',
+      r.tipo,
+      r.titulo,
+      r.descripcion,
+    ]);
+    exportToCSV(header, rows, 'DafoPlanesEstrategicos');
+  };
+
+  const exportPDF = () => {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text('DAFO Planes estratégicos', 10, 10);
+    let y = 20;
+    filtered.forEach((r) => {
+      doc.text(`${r.titulo} - ${r.tipo} - ${r.plan ? r.plan.nombre : ''}`, 10, y);
+      y += 10;
+    });
+    doc.save(`${formatDate()} DafoPlanesEstrategicos.pdf`);
+  };
+
+  const resetFilters = () => {
+    setSearch('');
+    setPlanFilter([]);
+    setTipoFilter([]);
+  };
+
+  const handleSort = (field) => {
+    const isAsc = sortField === field && sortDir === 'asc';
+    setSortField(field);
+    setSortDir(isAsc ? 'desc' : 'asc');
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        DAFO Planes estratégicos
+      </Typography>
+      <ListActions
+        onCreate={openNew}
+        onToggleFilter={() => setFilterOpen(!filterOpen)}
+        onOpenColumns={openSelector}
+        view={view}
+        onToggleView={() => setView(view === 'table' ? 'cards' : 'table')}
+        onExportCSV={exportCSV}
+        onExportPDF={exportPDF}
+        busy={busy}
+        sx={{ mb: 2 }}
+      />
+      {filterOpen && (
+        <Box sx={{ mb: 2, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          <TextField label="Buscar" value={search} onChange={(e) => setSearch(e.target.value)} />
+          <Autocomplete
+            multiple
+            options={planes}
+            getOptionLabel={(p) => p.nombre}
+            value={planFilter}
+            onChange={(e, val) => setPlanFilter(val)}
+            renderInput={(params) => <TextField {...params} label="Plan" />}
+          />
+          <Autocomplete
+            multiple
+            options={tipos}
+            getOptionLabel={(t) => t}
+            value={tipoFilter}
+            onChange={(e, val) => setTipoFilter(val)}
+            renderInput={(params) => <TextField {...params} label="Tipo" />}
+          />
+          <Button onClick={resetFilters}>Reset</Button>
+        </Box>
+      )}
+      {view === 'table' ? (
+        <Table>
+          <TableHead sx={tableHeadSx}>
+            <TableRow>
+              {columns.map((col) => (
+                <TableCell key={col.key}>
+                  <TableSortLabel
+                    active={sortField === col.key}
+                    direction={sortDir}
+                    onClick={() => handleSort(col.key)}
+                  >
+                    {col.label}
+                  </TableSortLabel>
+                </TableCell>
+              ))}
+              <TableCell>Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered.map((r) => (
+              <TableRow key={r.id}>
+                {columns.map((col) => (
+                  <TableCell key={col.key}>{col.render(r)}</TableCell>
+                ))}
+                <TableCell>
+                  <Tooltip title="Editar">
+                    <IconButton onClick={() => openEdit(r)} disabled={busy}>
+                      <span className="material-symbols-outlined">edit</span>
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar">
+                    <IconButton onClick={() => handleDelete(r.id)} disabled={busy}>
+                      <span className="material-symbols-outlined">delete</span>
+                    </IconButton>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {filtered.map((r) => (
+            <Card key={r.id} sx={{ width: 250 }}>
+              <CardContent>
+                <Typography variant="h6">{r.titulo}</Typography>
+                <Typography variant="body2">{r.tipo}</Typography>
+                <Typography variant="body2">{r.plan ? r.plan.nombre : ''}</Typography>
+                <Typography variant="body2" component="div">
+                  <span dangerouslySetInnerHTML={{ __html: marked.parse(r.descripcion || '') }} />
+                </Typography>
+                <Box sx={{ mt: 1 }}>
+                  <Tooltip title="Editar">
+                    <IconButton onClick={() => openEdit(r)} disabled={busy}>
+                      <span className="material-symbols-outlined">edit</span>
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar">
+                    <IconButton onClick={() => handleDelete(r.id)} disabled={busy}>
+                      <span className="material-symbols-outlined">delete</span>
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              </CardContent>
+            </Card>
+          ))}
+        </Box>
+      )}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
+        <DialogTitle>{current.id ? 'Editar registro DAFO' : 'Nuevo registro DAFO'}</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <Autocomplete
+            options={planes}
+            getOptionLabel={(p) => p.nombre}
+            value={current.plan}
+            onChange={(e, val) => setCurrent({ ...current, plan: val })}
+            renderInput={(params) => <TextField {...params} label="Plan estratégico*" />}
+          />
+          <Autocomplete
+            options={tipos}
+            getOptionLabel={(t) => t}
+            value={current.tipo}
+            onChange={(e, val) => setCurrent({ ...current, tipo: val })}
+            renderInput={(params) => <TextField {...params} label="Tipo*" />}
+          />
+          <TextField
+            label="Título*"
+            value={current.titulo}
+            onChange={(e) => setCurrent({ ...current, titulo: e.target.value })}
+          />
+          <TextField
+            label="Descripción"
+            multiline
+            minRows={3}
+            value={current.descripcion}
+            onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)} disabled={busy}>Cancelar</Button>
+          <Button onClick={handleSave} disabled={busy}>Guardar</Button>
+        </DialogActions>
+      </Dialog>
+      <ProcessingBanner seconds={seconds} />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add database table and API routes for DAFO records linked to strategic plans
- expose DAFO management UI with filtering, sorting, and CSV/PDF export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78dae7d3c83318ac14cc8ea7d6f23