### PR TITLE
Include all entities in import/export order

### DIFF
--- a/backend/routes/importExport.js
+++ b/backend/routes/importExport.js
@@ -12,11 +12,17 @@ router.get('/export', async (req, res) => {
     'programas_guardarrail',
     'programa_guardarrail_expertos',
     'principios_guardarrail',
+    'objetivos_guardarrail',
+    'objetivos_guardarrail_evidencias',
+    'dafo_pgr',
+    'principio_guardarrail_objetivos_guardarrail',
     'planes_estrategicos',
     'plan_estrategico_expertos',
     'principios_especificos',
+    'dafo_pe',
     'objetivos_estrategicos',
     'objetivos_estrategicos_evidencias',
+    'objetivo_guardarrail_planes',
     'preferencias_usuario',
   ];
   let sql = '';


### PR DESCRIPTION
## Summary
- export/import SQL now covers every data model table in dependency-aware order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78eea92cc8331b4285c72c1631b08