### PR TITLE
docs: add markdown formatting guidance for long text fields

### DIFF
--- a/docs/guardarails/AGENTS_03 UX_UI.MD
+++ b/docs/guardarails/AGENTS_03 UX_UI.MD
@@ -5,7 +5,7 @@ title: "Directrices UX/UI"
 # UI
 
 Todas las pantallas y funcionalidades de la aplicación deben cumplir las siguientes indicaciones:
-- Asegurate de que todos los campos obligatorios aparecen marcados visualmente como tal con un asterisco o similar. 
+- Asegurate de que todos los campos obligatorios aparecen marcados visualmente como tal con un asterisco o similar.
 - Desarrollaremos una interfaz de usuario basada en el estilo "material"
 - Todos los botones de acción que esten encima de listados de elementos (en formato tabla o cards) se visualizarán con un icono de estilo "material" correspondiente a la acción que permitan una mejor pulsación táctil en pantallas android . Cuando pongamos el ratón encima del botón con el icono, nos mostrará siempre en un tooltip la desripción de la acción que estamos realizando.
 - Las acciones de cancelar, guardar o aceptar en los formularios de edición aparecerán con el nombre de la acción en el botón.
@@ -14,6 +14,12 @@ Todas las pantallas y funcionalidades de la aplicación deben cumplir las siguie
 - Si existe un menú superior de perfil de usuario, este se mostrará siempre no con el nombre del menú sino con un icono de avatar.
 - Todas las interfaces deberán ser responsive, de forma que se adapten correctamente a la visualización en cualquier tipo de terminal: pc, tablet, móvil, etc.
 - Todos los botones de acciones sobre listados de elementos (tablas, cards, ec), se mostrarán con un icono y no con texto en el botón.
+
+## Formato Markdown en descripciones amplias
+- Todos los campos de descripción amplia del sistema permitirán formato **markdown**.
+- Los componentes de texto largo mostrarán las marcas **markdown** durante la edición, pero en modo solo lectura se renderizará el formato (por ejemplo, en celdas de tablas no editables).
+- Cada componente de texto largo tendrá encima un conjunto de botones con iconos que aplicarán al texto seleccionado el formato correspondiente.
+- Se ofrecerán botones para todas las opciones de formato admitidas por **markdown** (negrita, títulos, listas, etc.).
 
 ## Título de las pantallas
 - Todas las pantallas de gestión derivadas del menú principal mostrarán en la parte superior un título que identifique claramente la entidad que se está gestionando.
@@ -27,7 +33,7 @@ Todas las pantallas y funcionalidades de la aplicación deben cumplir las siguie
 - Si se van a eliminar registros en cascada, se debe informar al usuario de las nombres de las entidades de las que se van a eliminar registros.
 
 ## Creación y modificación de registros
-- asegurate de que todas las ediciones e inserciones de elementos una vez hechas, refrescan la lista de resultados par que se vean correctamente los nuevos datos. 
+- asegurate de que todas las ediciones e inserciones de elementos una vez hechas, refrescan la lista de resultados par que se vean correctamente los nuevos datos.
 
 ## Opciones de menú en los listados de elementos
 - Los listados de elementos tienen todos en su cabecera un pool de botones de acción que es común. Deben aparecer en el mismo orden en todas las listas de elementos, siendo el orden el siguiente:


### PR DESCRIPTION
## Summary
- document markdown support and toolbar requirements for long text fields in the UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a791662dac833188797bc044a63e02