### PR TITLE
docs: document organizations, normativa and inputs

### DIFF
--- a/docs/funcional/01 Modelo de datos.md
+++ b/docs/funcional/01 Modelo de datos.md
@@ -29,6 +29,31 @@ description: "Descripción de las entidades y campos de la aplicación"
 | descripcion | TEXT | NO |  |  |  |
 | propietario_id | INT | SI |  | usuarios.id | NO |
 
+## organizaciones
+| Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
+|-------|---------------|-------------|-------------------|------------|------------------------|
+| id | INT AUTO_INCREMENT | SI |  |  |  |
+| pmtde_id | INT | SI |  | pmtde.id | SI |
+| nombre | VARCHAR(255) | SI |  |  |  |
+
+## normativas
+| Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
+|-------|---------------|-------------|-------------------|------------|------------------------|
+| id | INT AUTO_INCREMENT | SI |  |  |  |
+| pmtde_id | INT | SI |  | pmtde.id | SI |
+| organizacion_id | INT | SI |  | organizaciones.id | SI |
+| nombre | VARCHAR(255) | SI |  |  |  |
+| url | VARCHAR(255) | NO |  |  |  |
+
+## inputs
+| Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
+|-------|---------------|-------------|-------------------|------------|------------------------|
+| id | INT AUTO_INCREMENT | SI |  |  |  |
+| pmtde_id | INT | SI |  | pmtde.id | SI |
+| normativa_id | INT | SI |  | normativas.id | SI |
+| titulo | VARCHAR(255) | SI |  |  |  |
+| descripcion | TEXT | NO |  |  |  |
+
 ## programas_guardarrail
 | Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
 |-------|---------------|-------------|-------------------|------------|------------------------|

--- a/docs/funcional/PMTDE/00 Menu PMTDE.md
+++ b/docs/funcional/PMTDE/00 Menu PMTDE.md
@@ -13,5 +13,8 @@ El menú **PMTDE** agrupa la gestión del Programa Marco de Transformación Digi
 Incluye el siguiente submenú en este orden:
 
 1. **PMTDE** – Administración de los programas marco.
+2. **Organizaciones** – Mantenimiento de las organizaciones asociadas a cada PMTDE.
+3. **Normativa** – Gestión de la normativa emitida por las organizaciones.
+4. **Inputs** – Cuestiones derivadas de la normativa que deben ejecutarse.
 
 Cada opción enlaza con los casos de uso descritos en los ficheros correspondientes.

--- a/docs/funcional/PMTDE/02 Organizaciones.md
+++ b/docs/funcional/PMTDE/02 Organizaciones.md
@@ -1,0 +1,75 @@
+---
+title: "Casos de Uso - Organizaciones"
+domain: "PMTDE"
+version: "1.0"
+date: "2025-08-18"
+author: "DGSIC"
+---
+
+# Casos de Uso: Organizaciones
+
+## Contexto
+Permite mantener la maestra de organizaciones asociadas a un PMTDE. Todos los campos obligatorios se marcan visualmente con un asterisco.
+
+---
+
+## Caso de Uso 1: Crear Organización
+**Actores principales:** Usuario administrador o gestor autorizado.
+
+**Flujo principal:**
+1. El usuario accede al submenú "Organizaciones".
+2. Elige "Crear nueva organización".
+3. Introduce:
+   - PMTDE asociado (obligatorio).
+   - Nombre de la organización (obligatorio).
+4. Confirma la acción.
+5. El sistema guarda el registro, deshabilita el botón durante el proceso y refresca la lista. Si la operación tarda más de un segundo se muestra un banner "Procesando... X seg".
+
+**Postcondiciones:**
+- La organización queda registrada dentro del PMTDE seleccionado.
+
+---
+
+## Caso de Uso 2: Editar Organización
+**Actores principales:** Usuario administrador o gestor autorizado.
+
+**Flujo principal:**
+1. El usuario selecciona una organización existente.
+2. Modifica cualquiera de los campos.
+3. Guarda los cambios.
+4. El sistema actualiza el registro y refresca la lista, deshabilitando el botón mientras procesa.
+
+**Postcondiciones:**
+- La organización se actualiza con la nueva información.
+
+---
+
+## Caso de Uso 3: Eliminar Organización
+**Actores principales:** Usuario administrador.
+
+**Flujo principal:**
+1. El usuario selecciona una organización y solicita su eliminación.
+2. El sistema solicita confirmación indicando que la acción es irreversible.
+3. Tras confirmar, se elimina la organización y se refresca la lista.
+
+**Postcondiciones:**
+- La organización desaparece del sistema.
+
+---
+
+## Caso de Uso 4: Listar Organizaciones
+**Actores principales:** Usuario.
+
+**Flujo principal:**
+1. El usuario abre el submenú "Organizaciones".
+2. El sistema muestra para cada organización:
+   - Nombre.
+   - PMTDE asociado.
+3. El usuario puede:
+   - Cambiar entre vista tabla o cards.
+   - Ordenar por cualquier columna.
+   - Abrir la sección de filtros para buscar texto, filtrar por PMTDE y reiniciar filtros.
+   - Exportar la lista a CSV (separador ";" y fechas entre comillas) o PDF.
+
+**Postcondiciones:**
+- El usuario visualiza las organizaciones según los filtros aplicados.

--- a/docs/funcional/PMTDE/03 Normativa.md
+++ b/docs/funcional/PMTDE/03 Normativa.md
@@ -1,0 +1,78 @@
+---
+title: "Casos de Uso - Normativa"
+domain: "PMTDE"
+version: "1.0"
+date: "2025-08-18"
+author: "DGSIC"
+---
+
+# Casos de Uso: Normativa
+
+## Contexto
+Gestiona la normativa emitida por las organizaciones dentro de un PMTDE. Los campos obligatorios aparecen marcados con un asterisco.
+
+---
+
+## Caso de Uso 1: Crear Normativa
+**Actores principales:** Usuario administrador o gestor autorizado.
+
+**Flujo principal:**
+1. El usuario accede al submenú "Normativa".
+2. Elige "Crear nueva normativa".
+3. Introduce:
+   - PMTDE asociado (obligatorio).
+   - Organización emisora (obligatoria).
+   - Nombre de la normativa (obligatorio).
+   - URL de consulta (opcional).
+4. Confirma la acción.
+5. El sistema guarda el registro, deshabilita el botón durante el proceso y refresca la lista. Si la operación tarda más de un segundo se muestra un banner "Procesando... X seg".
+
+**Postcondiciones:**
+- La normativa queda registrada vinculada a la organización seleccionada.
+
+---
+
+## Caso de Uso 2: Editar Normativa
+**Actores principales:** Usuario administrador o gestor autorizado.
+
+**Flujo principal:**
+1. El usuario selecciona una normativa existente.
+2. Modifica cualquiera de los campos.
+3. Guarda los cambios.
+4. El sistema actualiza el registro y refresca la lista, deshabilitando el botón mientras procesa.
+
+**Postcondiciones:**
+- La normativa se actualiza con la nueva información.
+
+---
+
+## Caso de Uso 3: Eliminar Normativa
+**Actores principales:** Usuario administrador.
+
+**Flujo principal:**
+1. El usuario selecciona una normativa y solicita su eliminación.
+2. El sistema solicita confirmación indicando que la acción es irreversible.
+3. Tras confirmar, se elimina la normativa y se refresca la lista.
+
+**Postcondiciones:**
+- La normativa desaparece del sistema.
+
+---
+
+## Caso de Uso 4: Listar Normativa
+**Actores principales:** Usuario.
+
+**Flujo principal:**
+1. El usuario abre el submenú "Normativa".
+2. El sistema muestra para cada normativa:
+   - Nombre.
+   - Organización emisora.
+   - URL.
+3. El usuario puede:
+   - Cambiar entre vista tabla o cards.
+   - Ordenar por cualquier columna.
+   - Abrir la sección de filtros para buscar texto, filtrar por organización y reiniciar filtros.
+   - Exportar la lista a CSV (separador ";" y fechas entre comillas) o PDF.
+
+**Postcondiciones:**
+- El usuario visualiza las normativas según los filtros aplicados.

--- a/docs/funcional/PMTDE/04 Inputs.md
+++ b/docs/funcional/PMTDE/04 Inputs.md
@@ -1,0 +1,77 @@
+---
+title: "Casos de Uso - Inputs"
+domain: "PMTDE"
+version: "1.0"
+date: "2025-08-18"
+author: "DGSIC"
+---
+
+# Casos de Uso: Inputs
+
+## Contexto
+Los inputs son las cuestiones que deben ejecutarse por exigencia de una normativa. Su mantenimiento permite gestionarlos como menú del PMTDE.
+
+---
+
+## Caso de Uso 1: Crear Input
+**Actores principales:** Usuario administrador o gestor autorizado.
+
+**Flujo principal:**
+1. El usuario accede al submenú "Inputs".
+2. Elige "Crear nuevo input".
+3. Introduce:
+   - PMTDE asociado (obligatorio).
+   - Normativa asociada (obligatoria). En el combo de selección se muestra el nombre de la normativa seguido entre paréntesis del nombre de la organización, permitiendo búsqueda por ambos valores.
+   - Título del input (obligatorio).
+   - Descripción (opcional).
+4. Confirma la acción.
+5. El sistema guarda el registro, deshabilita el botón durante el proceso y refresca la lista. Si la operación tarda más de un segundo se muestra un banner "Procesando... X seg".
+
+**Postcondiciones:**
+- El input queda registrado y asociado a la normativa seleccionada.
+
+---
+
+## Caso de Uso 2: Editar Input
+**Actores principales:** Usuario administrador o gestor autorizado.
+
+**Flujo principal:**
+1. El usuario selecciona un input existente.
+2. Modifica cualquiera de los campos.
+3. Guarda los cambios.
+4. El sistema actualiza el registro y refresca la lista, deshabilitando el botón mientras procesa.
+
+**Postcondiciones:**
+- El input se actualiza con la nueva información.
+
+---
+
+## Caso de Uso 3: Eliminar Input
+**Actores principales:** Usuario administrador.
+
+**Flujo principal:**
+1. El usuario selecciona un input y solicita su eliminación.
+2. El sistema solicita confirmación indicando que la acción es irreversible.
+3. Tras confirmar, se elimina el input y se refresca la lista.
+
+**Postcondiciones:**
+- El input desaparece del sistema.
+
+---
+
+## Caso de Uso 4: Listar Inputs
+**Actores principales:** Usuario.
+
+**Flujo principal:**
+1. El usuario abre el submenú "Inputs".
+2. El sistema muestra para cada input:
+   - Título.
+   - Normativa asociada (con el nombre de la organización entre paréntesis).
+3. El usuario puede:
+   - Cambiar entre vista tabla o cards.
+   - Ordenar por cualquier columna.
+   - Abrir la sección de filtros para buscar texto, filtrar por normativa y reiniciar filtros.
+   - Exportar la lista a CSV (separador ";" y fechas entre comillas) o PDF.
+
+**Postcondiciones:**
+- El usuario visualiza los inputs según los filtros aplicados.


### PR DESCRIPTION
## Summary
- expand PMTDE menu documentation with Organizaciones, Normativa and Inputs sections
- add functional docs for new entities with CRUD flows and list features
- update data model to include organizations, normativas and inputs tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a793cff82c8331a7270cb263e15458