### PR TITLE
Enable markdown formatting for extended text fields

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,6 +44,7 @@
   <script type="text/babel" data-presets="env,react" src="js/ImportExportApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/useProcessing.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProcessingBanner.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/MarkdownTextField.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PreferenciasApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/useColumnPreferences.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ListActions.js"></script>

--- a/frontend/js/DafoPlanesEstrategicosManager.js
+++ b/frontend/js/DafoPlanesEstrategicosManager.js
@@ -248,10 +248,8 @@ function DafoPlanesEstrategicosManager() {
             value={current.titulo}
             onChange={(e) => setCurrent({ ...current, titulo: e.target.value })}
           />
-          <TextField
+          <MarkdownTextField
             label="Descripción"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/ImportExportManager.js
+++ b/frontend/js/ImportExportManager.js
@@ -92,12 +92,8 @@ function ImportExportManager() {
           <Typography variant="h6" sx={{ mt: 2 }}>
             Logs
           </Typography>
-          <TextField
-            multiline
-            fullWidth
-            value={logs}
-            InputProps={{ readOnly: true }}
-          />
+          <Box sx={{ whiteSpace: 'pre-wrap' }}
+            dangerouslySetInnerHTML={{ __html: marked.parse(logs || '') }} />
         </Box>
       )}
     </Box>

--- a/frontend/js/MarkdownTextField.js
+++ b/frontend/js/MarkdownTextField.js
@@ -1,0 +1,47 @@
+const { TextField, IconButton, Box, Stack } = MaterialUI;
+
+const MarkdownTextField = ({ label, value, onChange, minRows = 3 }) => {
+  const ref = React.useRef();
+  const apply = (prefix, suffix = '') => {
+    const textarea = ref.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selected = value.substring(start, end);
+    const newVal = value.substring(0, start) + prefix + selected + suffix + value.substring(end);
+    onChange({ target: { value: newVal } });
+    setTimeout(() => {
+      textarea.focus();
+      textarea.setSelectionRange(start + prefix.length, start + prefix.length + selected.length);
+    });
+  };
+
+  const buttons = [
+    { icon: 'format_bold', fn: () => apply('**', '**') },
+    { icon: 'format_italic', fn: () => apply('*', '*') },
+    { icon: 'title', fn: () => apply('# ') },
+    { icon: 'format_list_bulleted', fn: () => apply('- ') },
+    { icon: 'link', fn: () => apply('[', '](url)') },
+  ];
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
+        {buttons.map((b) => (
+          <IconButton key={b.icon} onClick={b.fn} size="small">
+            <span className="material-symbols-outlined">{b.icon}</span>
+          </IconButton>
+        ))}
+      </Stack>
+      <TextField
+        inputRef={ref}
+        label={label}
+        value={value}
+        onChange={onChange}
+        multiline
+        minRows={minRows}
+        fullWidth
+      />
+    </Box>
+  );
+};

--- a/frontend/js/ObjetivosEstrategicosEvidenciasManager.js
+++ b/frontend/js/ObjetivosEstrategicosEvidenciasManager.js
@@ -2,7 +2,13 @@ function ObjetivosEstrategicosEvidenciasManager({ objetivo, onClose }) {
   const empty = { descripcion: '', codigo: '' };
   const columnsConfig = [
     { key: 'codigo', label: 'Código', render: (e) => e.codigo },
-    { key: 'descripcion', label: 'Descripción', render: (e) => e.descripcion },
+    {
+      key: 'descripcion',
+      label: 'Descripción',
+      render: (e) => (
+        <span dangerouslySetInnerHTML={{ __html: marked.parse(e.descripcion || '') }} />
+      ),
+    },
   ];
   const { columns, openSelector, selector } = useColumnPreferences(
     'objetivos_estrategicos_evidencias',
@@ -158,7 +164,9 @@ function ObjetivosEstrategicosEvidenciasManager({ objetivo, onClose }) {
               <Card key={e.id} sx={{ width: 250 }}>
                 <CardContent>
                   <Typography variant="h6">{e.codigo}</Typography>
-                  <Typography variant="body2">{e.descripcion}</Typography>
+                  <Typography variant="body2" component="div">
+                    <span dangerouslySetInnerHTML={{ __html: marked.parse(e.descripcion || '') }} />
+                  </Typography>
                   <Box sx={{ mt: 1 }}>
                     <Tooltip title="Editar">
                       <IconButton onClick={() => openEdit(e)} disabled={busy}>
@@ -185,10 +193,8 @@ function ObjetivosEstrategicosEvidenciasManager({ objetivo, onClose }) {
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar evidencia' : 'Nueva evidencia'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/ObjetivosEstrategicosManager.js
+++ b/frontend/js/ObjetivosEstrategicosManager.js
@@ -273,10 +273,8 @@ function ObjetivosEstrategicosManager() {
             value={current.titulo}
             onChange={(e) => setCurrent({ ...current, titulo: e.target.value })}
           />
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/ObjetivosGuardarrailEvidenciasManager.js
+++ b/frontend/js/ObjetivosGuardarrailEvidenciasManager.js
@@ -2,7 +2,13 @@ function ObjetivosGuardarrailEvidenciasManager({ objetivo, onClose }) {
   const empty = { descripcion: '', codigo: '' };
   const columnsConfig = [
     { key: 'codigo', label: 'Código', render: (e) => e.codigo },
-    { key: 'descripcion', label: 'Descripción', render: (e) => e.descripcion },
+    {
+      key: 'descripcion',
+      label: 'Descripción',
+      render: (e) => (
+        <span dangerouslySetInnerHTML={{ __html: marked.parse(e.descripcion || '') }} />
+      ),
+    },
   ];
   const { columns, openSelector, selector } = useColumnPreferences(
     'objetivos_guardarrail_evidencias',
@@ -158,7 +164,9 @@ function ObjetivosGuardarrailEvidenciasManager({ objetivo, onClose }) {
               <Card key={e.id} sx={{ width: 250 }}>
                 <CardContent>
                   <Typography variant="h6">{e.codigo}</Typography>
-                  <Typography variant="body2">{e.descripcion}</Typography>
+                  <Typography variant="body2" component="div">
+                    <span dangerouslySetInnerHTML={{ __html: marked.parse(e.descripcion || '') }} />
+                  </Typography>
                   <Box sx={{ mt: 1 }}>
                     <Tooltip title="Editar">
                       <IconButton onClick={() => openEdit(e)} disabled={busy}>
@@ -185,10 +193,8 @@ function ObjetivosGuardarrailEvidenciasManager({ objetivo, onClose }) {
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar evidencia' : 'Nueva evidencia'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/ObjetivosGuardarrailManager.js
+++ b/frontend/js/ObjetivosGuardarrailManager.js
@@ -325,10 +325,8 @@ function ObjetivosGuardarrailManager() {
             value={current.titulo}
             onChange={(e) => setCurrent({ ...current, titulo: e.target.value })}
           />
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/PlanesEstrategicosManager.js
+++ b/frontend/js/PlanesEstrategicosManager.js
@@ -324,10 +324,8 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
           value={current.nombre}
           onChange={(e) => setCurrent({ ...current, nombre: e.target.value })}
         />
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/PmtdeManager.js
+++ b/frontend/js/PmtdeManager.js
@@ -221,10 +221,8 @@ function PmtdeManager({ pmtde, setPmtde, usuarios }) {
             value={current.nombre}
             onChange={(e) => setCurrent({ ...current, nombre: e.target.value })}
           />
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/PrincipioGuardarrailManager.js
+++ b/frontend/js/PrincipioGuardarrailManager.js
@@ -239,10 +239,8 @@ function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuard
             value={current.titulo}
             onChange={(e) => setCurrent({ ...current, titulo: e.target.value })}
           />
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/PrincipiosEspecificosManager.js
+++ b/frontend/js/PrincipiosEspecificosManager.js
@@ -234,10 +234,8 @@ function PrincipiosEspecificosManager() {
             value={current.titulo}
             onChange={(e) => setCurrent({ ...current, titulo: e.target.value })}
           />
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />

--- a/frontend/js/ProgramaGuardarrailManager.js
+++ b/frontend/js/ProgramaGuardarrailManager.js
@@ -311,10 +311,8 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
             value={current.nombre}
             onChange={(e) => setCurrent({ ...current, nombre: e.target.value })}
           />
-          <TextField
+          <MarkdownTextField
             label="Descripción*"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
           />


### PR DESCRIPTION
## Summary
- add reusable MarkdownTextField with basic formatting toolbar
- render markdown in evidence lists and logs, using new field for editing descriptions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7944929b483318c4ccfe919cfbb0f