### PR TITLE
Add Normativas management

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -93,6 +93,23 @@ async function initDb() {
   if (defaultOrg.length === 0) {
     await pool.query("INSERT INTO organizaciones (id, pmtde_id, nombre) VALUES (1, 1, 'n/a')");
   }
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS normativas (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      pmtde_id INT NOT NULL,
+      organizacion_id INT NOT NULL,
+      nombre VARCHAR(255) NOT NULL,
+      url VARCHAR(255),
+      FOREIGN KEY (pmtde_id) REFERENCES pmtde(id) ON DELETE CASCADE,
+      FOREIGN KEY (organizacion_id) REFERENCES organizaciones(id) ON DELETE CASCADE
+    )`
+  );
+
+  const [defaultNorm] = await pool.query('SELECT id FROM normativas WHERE id=1');
+  if (defaultNorm.length === 0) {
+    await pool.query("INSERT INTO normativas (id, pmtde_id, organizacion_id, nombre, url) VALUES (1, 1, 1, 'n/a', 'n/a')");
+  }
+
 
   await pool.query(
     `CREATE TABLE IF NOT EXISTS programas_guardarrail (

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ const authRouter = require('./routes/auth');
 const usuariosRouter = require('./routes/usuarios');
 const pmtdeRouter = require('./routes/pmtde');
 const organizacionesRouter = require('./routes/organizaciones');
+const normativasRouter = require('./routes/normativas');
 const programasGuardarrailRouter = require('./routes/programasGuardarrail');
 const principiosGuardarrailRouter = require('./routes/principiosGuardarrail');
 const planesEstrategicosRouter = require('./routes/planesEstrategicos');
@@ -52,6 +53,7 @@ app.use((req, res, next) => {
 app.use('/api/usuarios', usuariosRouter);
 app.use('/api/pmtde', pmtdeRouter);
 app.use('/api/organizaciones', organizacionesRouter);
+app.use('/api/normativas', normativasRouter);
 app.use('/api/programasGuardarrail', programasGuardarrailRouter);
 app.use('/api/principiosGuardarrail', principiosGuardarrailRouter);
 app.use('/api/planesEstrategicos', planesEstrategicosRouter);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,6 +30,7 @@
   <script type="text/babel" data-presets="env,react" src="js/UsuariosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PmtdeApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/OrganizacionesApi.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/NormativasApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PrincipioGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosApi.js"></script>
@@ -53,6 +54,7 @@
   <script type="text/babel" data-presets="env,react" src="js/UsuariosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PmtdeManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/OrganizacionesManager.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/NormativasManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ProgramaGuardarrailManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PrincipioGuardarrailManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PlanesEstrategicosManager.js"></script>

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -5,6 +5,7 @@ function App() {
   const [usuarios, setUsuarios] = React.useState([]);
   const [pmtde, setPmtde] = React.useState([]);
   const [organizaciones, setOrganizaciones] = React.useState([]);
+  const [normativas, setNormativas] = React.useState([]);
   const [programasGuardarrail, setProgramasGuardarrail] = React.useState([]);
   const [principiosGuardarrail, setPrincipiosGuardarrail] = React.useState([]);
   const [parametros, setParametros] = React.useState([]);
@@ -23,6 +24,7 @@ function App() {
     usuariosApi.list().then(setUsuarios);
     pmtdeApi.list().then(setPmtde);
     organizacionesApi.list().then(setOrganizaciones);
+    normativasApi.list().then(setNormativas);
     programasGuardarrailApi.list().then(setProgramasGuardarrail);
     principiosGuardarrailApi.list().then(setPrincipiosGuardarrail);
     parametrosApi.list().then((params) => {
@@ -165,6 +167,12 @@ function App() {
                 </ListItemIcon>
                 <ListItemText primary="Organizaciones" />
               </ListItemButton>
+              <ListItemButton sx={{ pl: 4 }} onClick={() => go('normativas')}>
+                <ListItemIcon>
+                  <span className="material-symbols-outlined">gavel</span>
+                </ListItemIcon>
+                <ListItemText primary="Normativas" />
+              </ListItemButton>
             </List>
           </Collapse>
           <ListItemButton
@@ -272,6 +280,9 @@ function App() {
         )}
         {view === 'organizaciones' && (
           <OrganizacionesManager organizaciones={organizaciones} setOrganizaciones={setOrganizaciones} pmtde={pmtde} />
+        )}
+        {view === 'normativas' && (
+          <NormativasManager normativas={normativas} setNormativas={setNormativas} pmtde={pmtde} organizaciones={organizaciones} />
         )}
         {view === 'programasGuardarrail' && (
           <ProgramaGuardarrailManager

--- a/frontend/js/NormativasApi.js
+++ b/frontend/js/NormativasApi.js
@@ -1,0 +1,19 @@
+const normativasApi = {
+  list: async () => {
+    const res = await fetch('/api/normativas');
+    return res.json();
+  },
+  save: async (record) => {
+    const method = record.id ? 'PUT' : 'POST';
+    const url = record.id ? `/api/normativas/${record.id}` : '/api/normativas';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(record),
+    });
+    return res.json();
+  },
+  remove: async (id) => {
+    await fetch(`/api/normativas/${id}?confirm=true`, { method: 'DELETE' });
+  },
+};

--- a/frontend/js/NormativasManager.js
+++ b/frontend/js/NormativasManager.js
@@ -1,0 +1,240 @@
+function NormativasManager({ normativas, setNormativas, pmtde, organizaciones }) {
+  const columnsConfig = [
+    { key: 'nombre', label: 'Nombre', render: (n) => n.nombre },
+    {
+      key: 'organizacion',
+      label: 'Organización',
+      render: (n) => (n.organizacion ? n.organizacion.nombre : ''),
+    },
+    { key: 'url', label: 'URL', render: (n) => n.url },
+  ];
+  const { columns, openSelector, selector } = useColumnPreferences('normativas', columnsConfig);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [current, setCurrent] = React.useState({ nombre: '', pmtde: null, organizacion: null, url: '' });
+  const [view, setView] = React.useState('table');
+  const [filterOpen, setFilterOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+  const [orgFilter, setOrgFilter] = React.useState([]);
+  const [sortField, setSortField] = React.useState('nombre');
+  const [sortDir, setSortDir] = React.useState('asc');
+  const { busy, seconds, perform } = useProcessing();
+
+  const openNew = () => {
+    setCurrent({ nombre: '', pmtde: null, organizacion: null, url: '' });
+    setDialogOpen(true);
+  };
+
+  const openEdit = (n) => {
+    setCurrent(n);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    await perform(async () => {
+      await normativasApi.save(current);
+      const list = await normativasApi.list();
+      setNormativas(list);
+      setDialogOpen(false);
+    });
+  };
+
+  const handleDelete = (id) => {
+    if (!window.confirm('¿Eliminar normativa? Esta acción es irreversible.')) return;
+    perform(async () => {
+      await normativasApi.remove(id);
+      const list = await normativasApi.list();
+      setNormativas(list);
+    });
+  };
+
+  const filtered = normativas
+    .filter((n) => {
+      const txt = normalize(`${n.nombre} ${n.organizacion ? n.organizacion.nombre : ''} ${n.url}`);
+      const searchMatch = txt.includes(normalize(search));
+      const orgMatch = orgFilter.length
+        ? orgFilter.some((o) => o.id === (n.organizacion && n.organizacion.id))
+        : true;
+      return searchMatch && orgMatch;
+    })
+    .sort((a, b) => {
+      const getVal = (obj) => {
+        if (sortField === 'organizacion') {
+          return normalize(obj.organizacion ? obj.organizacion.nombre : '');
+        }
+        return normalize(obj[sortField] || '');
+      };
+      const valA = getVal(a);
+      const valB = getVal(b);
+      if (valA < valB) return sortDir === 'asc' ? -1 : 1;
+      if (valA > valB) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+
+  const exportCSV = () => {
+    const header = ['Nombre', 'Organización', 'URL'];
+    const rows = filtered.map((n) => [n.nombre, n.organizacion ? n.organizacion.nombre : '', n.url]);
+    exportToCSV(header, rows, 'Normativas');
+  };
+
+  const exportPDF = () => {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text('Normativas', 10, 10);
+    let y = 20;
+    filtered.forEach((n) => {
+      doc.text(`${n.nombre} - ${n.organizacion ? n.organizacion.nombre : ''} - ${n.url}`, 10, y);
+      y += 10;
+    });
+    doc.save(`${formatDate()} Normativas.pdf`);
+  };
+
+  const resetFilters = () => {
+    setSearch('');
+    setOrgFilter([]);
+  };
+
+  const handleSort = (field) => {
+    const isAsc = sortField === field && sortDir === 'asc';
+    setSortField(field);
+    setSortDir(isAsc ? 'desc' : 'asc');
+  };
+
+  const orgOptions = current.pmtde
+    ? organizaciones.filter((o) => o.pmtde && current.pmtde && o.pmtde.id === current.pmtde.id)
+    : organizaciones;
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <ProcessingBanner seconds={seconds} />
+      {selector}
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Normativas
+      </Typography>
+      <ListActions
+        onCreate={openNew}
+        onToggleFilter={() => setFilterOpen((o) => !o)}
+        onOpenColumns={openSelector}
+        view={view}
+        onToggleView={() => setView(view === 'table' ? 'cards' : 'table')}
+        onExportCSV={exportCSV}
+        onExportPDF={exportPDF}
+        busy={busy}
+      />
+
+      {filterOpen && (
+        <Box sx={{ mb: 2, display: 'flex', gap: 2, alignItems: 'center' }}>
+          <TextField label="Buscar" value={search} onChange={(e) => setSearch(e.target.value)} />
+          <Autocomplete
+            multiple
+            options={organizaciones}
+            getOptionLabel={(o) => o.nombre}
+            value={orgFilter}
+            onChange={(e, val) => setOrgFilter(val)}
+            renderInput={(params) => <TextField {...params} label="Organización" />}
+          />
+          <Button onClick={resetFilters}>Resetear</Button>
+        </Box>
+      )}
+
+      {view === 'table' ? (
+        <Table>
+          <TableHead sx={tableHeadSx}>
+            <TableRow>
+              {columns.map((c) => (
+                <TableCell key={c.key}>
+                  <TableSortLabel
+                    active={sortField === c.key}
+                    direction={sortDir}
+                    onClick={() => handleSort(c.key)}
+                  >
+                    {c.label}
+                  </TableSortLabel>
+                </TableCell>
+              ))}
+              <TableCell>Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered.map((n) => (
+              <TableRow key={n.id}>
+                {columns.map((c) => (
+                  <TableCell key={c.key}>{c.render(n)}</TableCell>
+                ))}
+                <TableCell>
+                  <Tooltip title="Editar">
+                    <IconButton onClick={() => openEdit(n)} disabled={busy}>
+                      <span className="material-symbols-outlined">edit</span>
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar">
+                    <IconButton onClick={() => handleDelete(n.id)} disabled={busy}>
+                      <span className="material-symbols-outlined">delete</span>
+                    </IconButton>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {filtered.map((n) => (
+            <Card key={n.id} sx={{ width: 250 }}>
+              <CardContent>
+                <Typography variant="h6">{n.nombre}</Typography>
+                <Typography variant="body2">{n.organizacion ? n.organizacion.nombre : ''}</Typography>
+                <Typography variant="body2">{n.url}</Typography>
+                <Box sx={{ mt: 1 }}>
+                  <Tooltip title="Editar">
+                    <IconButton onClick={() => openEdit(n)} disabled={busy}>
+                      <span className="material-symbols-outlined">edit</span>
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar">
+                    <IconButton onClick={() => handleDelete(n.id)} disabled={busy}>
+                      <span className="material-symbols-outlined">delete</span>
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              </CardContent>
+            </Card>
+          ))}
+        </Box>
+      )}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
+        <DialogTitle>{current.id ? 'Editar normativa' : 'Nueva normativa'}</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            label="Nombre*"
+            value={current.nombre}
+            onChange={(e) => setCurrent({ ...current, nombre: e.target.value })}
+          />
+          <Autocomplete
+            options={pmtde}
+            getOptionLabel={(p) => p.nombre}
+            value={current.pmtde}
+            onChange={(e, val) => setCurrent({ ...current, pmtde: val, organizacion: null })}
+            renderInput={(params) => <TextField {...params} label="PMTDE*" />}
+          />
+          <Autocomplete
+            options={orgOptions}
+            getOptionLabel={(o) => o.nombre}
+            value={current.organizacion}
+            onChange={(e, val) => setCurrent({ ...current, organizacion: val })}
+            renderInput={(params) => <TextField {...params} label="Organización*" />}
+          />
+          <TextField
+            label="URL"
+            value={current.url}
+            onChange={(e) => setCurrent({ ...current, url: e.target.value })}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)} disabled={busy}>Cancelar</Button>
+          <Button onClick={handleSave} disabled={busy}>Guardar</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add database table and backend API for normativas
- integrate normativas CRUD view with filters, exports and card/table switch
- link normativas menu item into application

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a796bbf8d883319f82ef4ab64bf9ac