### PR TITLE
Move DAFO Planes estratégicos submenu

### DIFF
--- a/docs/funcional/use-cases/planes-estrategicos/01 Planes estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/01 Planes estrategicos.md
@@ -10,7 +10,7 @@ author: "DGSIC"
 
 ## Contexto
 La aplicación permite gestionar Planes estratégicos vinculados a los PMTDE.
-En el menú "Planes estratégicos", el submenú "Planes" se muestra en primer lugar, seguido de "Principios específicos" y "Objetivos estratégicos".
+En el menú "Planes estratégicos", el submenú "Planes" se muestra en primer lugar, seguido de "Principios específicos", "Objetivos estratégicos" y "DAFO Planes estratégicos".
 
 ---
 

--- a/docs/funcional/use-cases/planes-estrategicos/02 Principios especificos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/02 Principios especificos.md
@@ -10,7 +10,7 @@ author: "DGSIC"
 
 ## Contexto
 La aplicación permite gestionar principios específicos vinculados a los planes estratégicos.
-Dentro del menú "Planes estratégicos", el submenú "Principios específicos" se muestra en segundo lugar, precedido por "Planes" y seguido de "Objetivos estratégicos".
+Dentro del menú "Planes estratégicos", el submenú "Principios específicos" se muestra en segundo lugar, precedido por "Planes" y seguido de "Objetivos estratégicos" y "DAFO Planes estratégicos".
 
 ---
 

--- a/docs/funcional/use-cases/planes-estrategicos/03 Objetivos Estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/03 Objetivos Estrategicos.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: Gestión de Objetivos Estratégicos
 
 ## Contexto
-El submenú "Objetivos estratégicos" forma parte del menú "Planes estratégicos" y se ubica en tercer lugar, después de "Planes" y "Principios específicos".
+El submenú "Objetivos estratégicos" forma parte del menú "Planes estratégicos" y se ubica en tercer lugar, después de "Planes" y "Principios específicos" y antes de "DAFO Planes estratégicos".
 Cada **objetivo estratégico** está vinculado obligatoriamente a un **plan estratégico** y podrá contener **evidencias** asociadas.
 
 ---

--- a/docs/funcional/use-cases/planes-estrategicos/04 DAFO Planes Estratégicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/04 DAFO Planes Estratégicos.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: Matrices DAFO de Planes Estratégicos
 
 ## Contexto
-La aplicación permite gestionar registros **DAFO** asociados a un **plan estratégico**. Cada registro se vincula a un plan y se clasifica por tipo. Todas las pantallas relacionadas muestran en la parte superior un título con el nombre de la entidad para facilitar la identificación.
+La aplicación permite gestionar registros **DAFO** asociados a un **plan estratégico**. Cada registro se vincula a un plan y se clasifica por tipo. Todas las pantallas relacionadas muestran en la parte superior un título con el nombre de la entidad para facilitar la identificación. Dentro del menú "Planes estratégicos", el submenú "DAFO Planes estratégicos" se muestra en último lugar.
 
 ---
 

--- a/docs/funcional/use-cases/programas-guardarrailes/05 DAFO Programas Guardarrail.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/05 DAFO Programas Guardarrail.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: Registros DAFO de Programas Guardarrail
 
 ## Contexto
-La aplicación permite gestionar registros **DAFO** (Debilidades, Amenazas, Fortalezas y Oportunidades) asociados a un **programa guardarrail**. Cada registro se vincula a un programa y se clasifica por tipo. Todas las pantallas relacionadas muestran en la parte superior un título con el nombre de la entidad para facilitar la identificación.
+La aplicación permite gestionar registros **DAFO** (Debilidades, Amenazas, Fortalezas y Oportunidades) asociados a un **programa guardarrail**. Cada registro se vincula a un programa y se clasifica por tipo. Todas las pantallas relacionadas muestran en la parte superior un título con el nombre de la entidad para facilitar la identificación. Dentro del menú "Programas guardarrail", el submenú "DAFO Programas guardarrail" se presenta como última opción.
 
 ---
 

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -207,6 +207,12 @@ function App() {
                 </ListItemIcon>
                 <ListItemText primary="Trazabilidad principios GR vs objetivos GR" />
               </ListItemButton>
+              <ListItemButton sx={{ pl: 4 }} onClick={() => go('dafoProgramasGuardarrail')}>
+                <ListItemIcon>
+                  <span className="material-symbols-outlined">category</span>
+                </ListItemIcon>
+                <ListItemText primary="DAFO Programas guardarrail" />
+              </ListItemButton>
             </List>
           </Collapse>
 
@@ -243,13 +249,7 @@ function App() {
                 <ListItemIcon>
                   <span className="material-symbols-outlined">category</span>
                 </ListItemIcon>
-                <ListItemText primary="DAFO" />
-              </ListItemButton>
-              <ListItemButton sx={{ pl: 4 }} onClick={() => go('dafoProgramasGuardarrail')}>
-                <ListItemIcon>
-                  <span className="material-symbols-outlined">category</span>
-                </ListItemIcon>
-                <ListItemText primary="DAFO programas guardarrail" />
+                <ListItemText primary="DAFO Planes estratégicos" />
               </ListItemButton>
             </List>
           </Collapse>


### PR DESCRIPTION
## Summary
- Move "DAFO Programas guardarrail" into the "Programas Guardarrail" menu and display "DAFO Planes estratégicos" as the last item in the "Planes Estratégicos" menu
- Refresh use-case docs to reflect new submenu positions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a797c729f0833185c4b9382a3d0cc6