### PR TITLE
Fix DAFO column selector and type display

### DIFF
--- a/docs/funcional/use-cases/planes-estrategicos/04 DAFO Planes Estratégicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/04 DAFO Planes Estratégicos.md
@@ -72,7 +72,7 @@ La aplicación permite gestionar registros **DAFO** asociados a un **plan estrat
 1. El usuario abre el submenú "DAFO".
 2. El sistema muestra para cada registro:
    - Plan Estratégico.
-   - Tipo.
+   - Tipo (códigos **D**, **A**, **F**, **O** con *tooltip* "Debilidad", "Amenaza", "Fortaleza" u "Oportunidad").
    - Título.
    - Descripción.
 3. El usuario dispone de los siguientes controles en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.

--- a/docs/funcional/use-cases/programas-guardarrailes/05 DAFO Programas Guardarrail.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/05 DAFO Programas Guardarrail.md
@@ -72,7 +72,7 @@ La aplicación permite gestionar registros **DAFO** (Debilidades, Amenazas, Fort
 1. El usuario abre el submenú "DAFO".
 2. El sistema muestra para cada registro:
    - Programa Guardarrail.
-   - Tipo.
+   - Tipo (códigos **D**, **A**, **F**, **O** con *tooltip* "Debilidad", "Amenaza", "Fortaleza" u "Oportunidad").
    - Título.
    - Descripción.
 3. El usuario dispone de los siguientes controles en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.

--- a/frontend/js/DafoPlanesEstrategicosManager.js
+++ b/frontend/js/DafoPlanesEstrategicosManager.js
@@ -12,7 +12,15 @@ function DafoPlanesEstrategicosManager() {
   const empty = { plan: null, tipo: '', titulo: '', descripcion: '' };
   const columnsConfig = [
     { key: 'plan', label: 'Plan estratégico', render: (d) => (d.plan ? d.plan.nombre : '') },
-    { key: 'tipo', label: 'Tipo', render: (d) => getTipoLabel(d.tipo) },
+    {
+      key: 'tipo',
+      label: 'Tipo',
+      render: (d) => (
+        <Tooltip title={getTipoLabel(d.tipo)}>
+          <span>{d.tipo}</span>
+        </Tooltip>
+      ),
+    },
     { key: 'titulo', label: 'Título', render: (d) => d.titulo },
     {
       key: 'descripcion',
@@ -137,6 +145,8 @@ function DafoPlanesEstrategicosManager() {
 
   return (
     <Box sx={{ p: 2 }}>
+      <ProcessingBanner seconds={seconds} />
+      {selector}
       <Typography variant="h5" sx={{ mb: 2 }}>
         DAFO Planes estratégicos
       </Typography>
@@ -219,7 +229,9 @@ function DafoPlanesEstrategicosManager() {
             <Card key={r.id} sx={{ width: 250 }}>
               <CardContent>
                 <Typography variant="h6">{r.titulo}</Typography>
-                <Typography variant="body2">{getTipoLabel(r.tipo)}</Typography>
+                <Tooltip title={getTipoLabel(r.tipo)}>
+                  <Typography variant="body2">{r.tipo}</Typography>
+                </Tooltip>
                 <Typography variant="body2">{r.plan ? r.plan.nombre : ''}</Typography>
                 <Typography variant="body2" component="div">
                   <span dangerouslySetInnerHTML={{ __html: marked.parse(r.descripcion || '') }} />
@@ -277,7 +289,6 @@ function DafoPlanesEstrategicosManager() {
           <Button onClick={handleSave} disabled={busy}>Guardar</Button>
         </DialogActions>
       </Dialog>
-      <ProcessingBanner seconds={seconds} />
     </Box>
   );
 }

--- a/frontend/js/DafoProgramasGuardarrailManager.js
+++ b/frontend/js/DafoProgramasGuardarrailManager.js
@@ -1,9 +1,26 @@
 function DafoProgramasGuardarrailManager() {
-  const tipos = ['Debilidad', 'Amenaza', 'Fortaleza', 'Oportunidad'];
+  const tipoOptions = [
+    { value: 'D', label: 'Debilidad' },
+    { value: 'A', label: 'Amenaza' },
+    { value: 'F', label: 'Fortaleza' },
+    { value: 'O', label: 'Oportunidad' },
+  ];
+  const getTipoLabel = (val) => {
+    const found = tipoOptions.find((t) => t.value === val);
+    return found ? found.label : val;
+  };
   const empty = { programa: null, tipo: '', titulo: '', descripcion: '' };
   const columnsConfig = [
     { key: 'programa', label: 'Programa guardarrail', render: (d) => (d.programa ? d.programa.nombre : '') },
-    { key: 'tipo', label: 'Tipo', render: (d) => d.tipo },
+    {
+      key: 'tipo',
+      label: 'Tipo',
+      render: (d) => (
+        <Tooltip title={getTipoLabel(d.tipo)}>
+          <span>{d.tipo}</span>
+        </Tooltip>
+      ),
+    },
     { key: 'titulo', label: 'Título', render: (d) => d.titulo },
     {
       key: 'descripcion',
@@ -63,7 +80,9 @@ function DafoProgramasGuardarrailManager() {
   const filtered = registros
     .filter((r) => {
       const txt = normalize(
-        `${r.titulo} ${r.descripcion || ''} ${r.tipo} ${r.programa ? r.programa.nombre : ''}`
+        `${r.titulo} ${r.descripcion || ''} ${getTipoLabel(r.tipo)} ${
+          r.programa ? r.programa.nombre : ''
+        }`
       );
       const searchMatch = txt.includes(normalize(search));
       const programaMatch = programaFilter.length
@@ -75,6 +94,7 @@ function DafoProgramasGuardarrailManager() {
     .sort((a, b) => {
       const getVal = (obj) => {
         if (sortField === 'programa') return normalize(obj.programa ? obj.programa.nombre : '');
+        if (sortField === 'tipo') return normalize(getTipoLabel(obj.tipo));
         return normalize(obj[sortField] || '');
       };
       const valA = getVal(a);
@@ -88,7 +108,7 @@ function DafoProgramasGuardarrailManager() {
     const header = ['Programa', 'Tipo', 'Título', 'Descripción'];
     const rows = filtered.map((r) => [
       r.programa ? r.programa.nombre : '',
-      r.tipo,
+      getTipoLabel(r.tipo),
       r.titulo,
       r.descripcion,
     ]);
@@ -101,7 +121,11 @@ function DafoProgramasGuardarrailManager() {
     doc.text('DAFO Programas guardarrail', 10, 10);
     let y = 20;
     filtered.forEach((r) => {
-      doc.text(`${r.titulo} - ${r.tipo} - ${r.programa ? r.programa.nombre : ''}`, 10, y);
+      doc.text(
+        `${r.titulo} - ${getTipoLabel(r.tipo)} - ${r.programa ? r.programa.nombre : ''}`,
+        10,
+        y
+      );
       y += 10;
     });
     doc.save(`${formatDate()} DafoProgramasGuardarrail.pdf`);
@@ -148,10 +172,10 @@ function DafoProgramasGuardarrailManager() {
           />
           <Autocomplete
             multiple
-            options={tipos}
-            getOptionLabel={(t) => t}
-            value={tipoFilter}
-            onChange={(e, val) => setTipoFilter(val)}
+            options={tipoOptions}
+            getOptionLabel={(t) => t.label}
+            value={tipoFilter.map((tf) => tipoOptions.find((t) => t.value === tf))}
+            onChange={(e, val) => setTipoFilter(val.map((t) => t.value))}
             renderInput={(params) => <TextField {...params} label="Tipo" />}
           />
           <Button onClick={resetFilters}>Reset</Button>
@@ -204,7 +228,9 @@ function DafoProgramasGuardarrailManager() {
             <Card key={r.id} sx={{ width: 250 }}>
               <CardContent>
                 <Typography variant="h6">{r.titulo}</Typography>
-                <Typography variant="body2">{r.tipo}</Typography>
+                <Tooltip title={getTipoLabel(r.tipo)}>
+                  <Typography variant="body2">{r.tipo}</Typography>
+                </Tooltip>
                 <Typography variant="body2">{r.programa ? r.programa.nombre : ''}</Typography>
                 <Typography variant="body2" component="div">
                   <span dangerouslySetInnerHTML={{ __html: marked.parse(r.descripcion || '') }} />
@@ -238,10 +264,12 @@ function DafoProgramasGuardarrailManager() {
             renderInput={(params) => <TextField {...params} label="Programa guardarrail*" />}
           />
           <Autocomplete
-            options={tipos}
-            getOptionLabel={(t) => t}
-            value={current.tipo}
-            onChange={(e, val) => setCurrent({ ...current, tipo: val })}
+            options={tipoOptions}
+            getOptionLabel={(t) => t.label}
+            value={tipoOptions.find((t) => t.value === current.tipo) || null}
+            onChange={(e, val) =>
+              setCurrent({ ...current, tipo: val ? val.value : '' })
+            }
             renderInput={(params) => <TextField {...params} label="Tipo*" />}
           />
           <TextField


### PR DESCRIPTION
## Summary
- show DAFO types as codes with tooltips in Planes estratégicos and Programas guardarrail
- render column selector in Planes estratégicos lists
- document DAFO type code display in corresponding use cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7986747b88331bbf88b30c648bd69