### PR TITLE
Ensure DAFO Programas descriptions use markdown field

### DIFF
--- a/docs/guardarails/AGENTS_03 UX_UI.MD
+++ b/docs/guardarails/AGENTS_03 UX_UI.MD
@@ -20,6 +20,7 @@ Todas las pantallas y funcionalidades de la aplicación deben cumplir las siguie
 - Los componentes de texto largo mostrarán las marcas **markdown** durante la edición, pero en modo solo lectura se renderizará el formato (por ejemplo, en celdas de tablas no editables).
 - Cada componente de texto largo tendrá encima un conjunto de botones con iconos que aplicarán al texto seleccionado el formato correspondiente.
 - Se ofrecerán botones para todas las opciones de formato admitidas por **markdown** (negrita, títulos, listas, etc.).
+- Todos los campos definidos como tipo **TEXT** en el modelo de datos deberán editarse mediante el componente `MarkdownTextField` y cumplir estas directrices de formato **markdown**.
 
 ## Título de las pantallas
 - Todas las pantallas de gestión derivadas del menú principal mostrarán en la parte superior un título que identifique claramente la entidad que se está gestionando.

--- a/frontend/js/DafoProgramasGuardarrailManager.js
+++ b/frontend/js/DafoProgramasGuardarrailManager.js
@@ -249,12 +249,11 @@ function DafoProgramasGuardarrailManager() {
             value={current.titulo}
             onChange={(e) => setCurrent({ ...current, titulo: e.target.value })}
           />
-          <TextField
+          <MarkdownTextField
             label="Descripción"
-            multiline
-            minRows={3}
             value={current.descripcion}
             onChange={(e) => setCurrent({ ...current, descripcion: e.target.value })}
+            minRows={3}
           />
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
## Summary
- Replace plain text description editor with MarkdownTextField for DAFO Programas guardarrail.
- Document requirement that all TEXT fields use MarkdownTextField per markdown guidelines.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a798fda4048331af4f53b001eb2f31