### PR TITLE
Fix export of trazabilidad table

### DIFF
--- a/backend/routes/importExport.js
+++ b/backend/routes/importExport.js
@@ -15,7 +15,7 @@ router.get('/export', async (req, res) => {
     'objetivos_guardarrail',
     'objetivos_guardarrail_evidencias',
     'dafo_pgr',
-    'principio_guardarrail_objetivos_guardarrail',
+    'principioGR_objetivoGR_trazabilidad',
     'planes_estrategicos',
     'plan_estrategico_expertos',
     'principios_especificos',

--- a/docs/funcional/01 Modelo de datos.md
+++ b/docs/funcional/01 Modelo de datos.md
@@ -111,11 +111,12 @@ description: "Descripción de las entidades y campos de la aplicación"
 | titulo | VARCHAR(255) | SI |  |  |  |
 | descripcion | TEXT | NO |  |  |  |
 
-## principio_guardarrail_objetivos_guardarrail
+## principioGR_objetivoGR_trazabilidad
 | Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
 |-------|---------------|-------------|-------------------|------------|------------------------|
-| principio_id | INT | SI |  | principios_guardarrail.id | SI |
-| objetivo_id | INT | SI |  | objetivos_guardarrail.id | SI |
+| programa_id | INT | SI |  | programas_guardarrail.id | SI |
+| principioGR_id | INT | SI |  | principios_guardarrail.id | SI |
+| objetivoGR_id | INT | SI |  | objetivos_guardarrail.id | SI |
 | nivel | INT | SI | 0 |  |  |
 
 ## planes_estrategicos


### PR DESCRIPTION
## Summary
- correct export route to use `principioGR_objetivoGR_trazabilidad`
- update data model docs for `principioGR_objetivoGR_trazabilidad`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a799c6891c8331a1600173493b6c6f