### PR TITLE
feat: add codes for core entities

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -84,20 +84,29 @@ async function initDb() {
     `CREATE TABLE IF NOT EXISTS organizaciones (
       id INT AUTO_INCREMENT PRIMARY KEY,
       pmtde_id INT NOT NULL,
+      codigo VARCHAR(10) NOT NULL,
       nombre VARCHAR(255) NOT NULL,
       FOREIGN KEY (pmtde_id) REFERENCES pmtde(id) ON DELETE CASCADE
     )`
   );
 
+  await pool.query(
+    "ALTER TABLE organizaciones ADD COLUMN IF NOT EXISTS codigo VARCHAR(10) NOT NULL"
+  );
+  await pool.query(
+    "UPDATE organizaciones SET codigo='n/a' WHERE codigo IS NULL OR codigo=''"
+  );
+
   const [defaultOrg] = await pool.query('SELECT id FROM organizaciones WHERE id=1');
   if (defaultOrg.length === 0) {
-    await pool.query("INSERT INTO organizaciones (id, pmtde_id, nombre) VALUES (1, 1, 'n/a')");
+    await pool.query("INSERT INTO organizaciones (id, pmtde_id, codigo, nombre) VALUES (1, 1, 'n/a', 'n/a')");
   }
   await pool.query(
     `CREATE TABLE IF NOT EXISTS normativas (
       id INT AUTO_INCREMENT PRIMARY KEY,
       pmtde_id INT NOT NULL,
       organizacion_id INT NOT NULL,
+      codigo VARCHAR(10) NOT NULL,
       nombre VARCHAR(255) NOT NULL,
       url VARCHAR(255),
       FOREIGN KEY (pmtde_id) REFERENCES pmtde(id) ON DELETE CASCADE,
@@ -105,9 +114,16 @@ async function initDb() {
     )`
   );
 
+  await pool.query(
+    "ALTER TABLE normativas ADD COLUMN IF NOT EXISTS codigo VARCHAR(10) NOT NULL"
+  );
+  await pool.query(
+    "UPDATE normativas SET codigo='n/a' WHERE codigo IS NULL OR codigo=''"
+  );
+
   const [defaultNorm] = await pool.query('SELECT id FROM normativas WHERE id=1');
   if (defaultNorm.length === 0) {
-    await pool.query("INSERT INTO normativas (id, pmtde_id, organizacion_id, nombre, url) VALUES (1, 1, 1, 'n/a', 'n/a')");
+    await pool.query("INSERT INTO normativas (id, pmtde_id, organizacion_id, codigo, nombre, url) VALUES (1, 1, 1, 'n/a', 'n/a', 'n/a')");
   }
 
 
@@ -116,6 +132,7 @@ async function initDb() {
       id INT AUTO_INCREMENT PRIMARY KEY,
       pmtde_id INT NOT NULL,
       normativa_id INT NOT NULL,
+      codigo VARCHAR(255) NOT NULL,
       titulo VARCHAR(255) NOT NULL,
       descripcion TEXT,
       FOREIGN KEY (pmtde_id) REFERENCES pmtde(id) ON DELETE CASCADE,
@@ -123,12 +140,18 @@ async function initDb() {
     )`
   );
   await pool.query(
+    "ALTER TABLE inputs ADD COLUMN IF NOT EXISTS codigo VARCHAR(255) NOT NULL"
+  );
+  await pool.query(
+    "UPDATE inputs SET codigo='n/a' WHERE codigo IS NULL OR codigo=''"
+  );
+  await pool.query(
     "ALTER TABLE inputs MODIFY COLUMN descripcion TEXT"
   );
   const [defaultInput] = await pool.query('SELECT id FROM inputs WHERE id=1');
   if (defaultInput.length === 0) {
     await pool.query(
-      "INSERT INTO inputs (id, pmtde_id, normativa_id, titulo, descripcion) VALUES (1, 1, 1, 'n/a', 'n/a')"
+      "INSERT INTO inputs (id, pmtde_id, normativa_id, codigo, titulo, descripcion) VALUES (1, 1, 1, 'n/a', 'n/a', 'n/a')"
     );
   }
 

--- a/backend/routes/inputs.js
+++ b/backend/routes/inputs.js
@@ -6,10 +6,11 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   const pool = getDb();
   const [rows] = await pool.query(
-    'SELECT i.id, i.titulo, i.descripcion, i.pmtde_id, p.nombre AS pmtde_nombre, i.normativa_id, n.nombre AS normativa_nombre, n.organizacion_id, o.nombre AS organizacion_nombre FROM inputs i LEFT JOIN pmtde p ON i.pmtde_id=p.id LEFT JOIN normativas n ON i.normativa_id=n.id LEFT JOIN organizaciones o ON n.organizacion_id=o.id'
+    'SELECT i.id, i.codigo, i.titulo, i.descripcion, i.pmtde_id, p.nombre AS pmtde_nombre, i.normativa_id, n.nombre AS normativa_nombre, n.codigo AS normativa_codigo, n.organizacion_id, o.nombre AS organizacion_nombre, o.codigo AS organizacion_codigo FROM inputs i LEFT JOIN pmtde p ON i.pmtde_id=p.id LEFT JOIN normativas n ON i.normativa_id=n.id LEFT JOIN organizaciones o ON n.organizacion_id=o.id'
   );
   const result = rows.map((r) => ({
     id: r.id,
+    codigo: r.codigo,
     titulo: r.titulo,
     descripcion: r.descripcion,
     pmtde: r.pmtde_id ? { id: r.pmtde_id, nombre: r.pmtde_nombre } : null,
@@ -17,7 +18,10 @@ router.get('/', async (req, res) => {
       ? {
           id: r.normativa_id,
           nombre: r.normativa_nombre,
-          organizacion: r.organizacion_id ? { id: r.organizacion_id, nombre: r.organizacion_nombre } : null,
+          codigo: r.normativa_codigo,
+          organizacion: r.organizacion_id
+            ? { id: r.organizacion_id, nombre: r.organizacion_nombre, codigo: r.organizacion_codigo }
+            : null,
         }
       : null,
   }));
@@ -30,11 +34,23 @@ router.post('/', async (req, res) => {
   const normativaId = req.body.normativa && req.body.normativa.id ? req.body.normativa.id : 1;
   const titulo = req.body.titulo || 'n/a';
   const descripcion = req.body.descripcion || 'n/a';
-  const [result] = await pool.query(
-    'INSERT INTO inputs (pmtde_id, normativa_id, titulo, descripcion) VALUES (?, ?, ?, ?)',
-    [pmtdeId, normativaId, titulo, descripcion]
+
+  const [[codes]] = await pool.query(
+    'SELECT n.codigo AS norm_codigo, o.codigo AS org_codigo FROM normativas n JOIN organizaciones o ON n.organizacion_id=o.id WHERE n.id=?',
+    [normativaId]
   );
-  res.json({ id: result.insertId, ...req.body });
+  const [existing] = await pool.query('SELECT codigo FROM inputs WHERE normativa_id=?', [normativaId]);
+  const next = existing.reduce((m, r) => {
+    const num = parseInt(r.codigo.split('.').pop(), 10) || 0;
+    return Math.max(m, num);
+  }, 0) + 1;
+  const codigo = `${codes.org_codigo}.${codes.norm_codigo}.${next}`;
+
+  const [result] = await pool.query(
+    'INSERT INTO inputs (pmtde_id, normativa_id, codigo, titulo, descripcion) VALUES (?, ?, ?, ?, ?)',
+    [pmtdeId, normativaId, codigo, titulo, descripcion]
+  );
+  res.json({ id: result.insertId, codigo, titulo, descripcion, pmtde: req.body.pmtde, normativa: req.body.normativa });
 });
 
 router.put('/:id', async (req, res) => {
@@ -43,11 +59,30 @@ router.put('/:id', async (req, res) => {
   const normativaId = req.body.normativa && req.body.normativa.id ? req.body.normativa.id : 1;
   const titulo = req.body.titulo || 'n/a';
   const descripcion = req.body.descripcion || 'n/a';
-  await pool.query(
-    'UPDATE inputs SET pmtde_id=?, normativa_id=?, titulo=?, descripcion=? WHERE id=?',
-    [pmtdeId, normativaId, titulo, descripcion, req.params.id]
+
+  const [[prev]] = await pool.query(
+    'SELECT normativa_id, codigo FROM inputs WHERE id=?',
+    [req.params.id]
   );
-  res.json({ id: parseInt(req.params.id, 10), ...req.body });
+  let codigo = prev.codigo;
+  if (prev.normativa_id !== normativaId) {
+    const [[codes]] = await pool.query(
+      'SELECT n.codigo AS norm_codigo, o.codigo AS org_codigo FROM normativas n JOIN organizaciones o ON n.organizacion_id=o.id WHERE n.id=?',
+      [normativaId]
+    );
+    const [existing] = await pool.query('SELECT codigo FROM inputs WHERE normativa_id=?', [normativaId]);
+    const next = existing.reduce((m, r) => {
+      const num = parseInt(r.codigo.split('.').pop(), 10) || 0;
+      return Math.max(m, num);
+    }, 0) + 1;
+    codigo = `${codes.org_codigo}.${codes.norm_codigo}.${next}`;
+  }
+
+  await pool.query(
+    'UPDATE inputs SET pmtde_id=?, normativa_id=?, codigo=?, titulo=?, descripcion=? WHERE id=?',
+    [pmtdeId, normativaId, codigo, titulo, descripcion, req.params.id]
+  );
+  res.json({ id: parseInt(req.params.id, 10), codigo, titulo, descripcion, pmtde: req.body.pmtde, normativa: req.body.normativa });
 });
 
 router.delete('/:id', async (req, res) => {

--- a/backend/routes/normativas.js
+++ b/backend/routes/normativas.js
@@ -6,14 +6,17 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   const pool = getDb();
   const [rows] = await pool.query(
-    'SELECT n.id, n.nombre, n.url, n.pmtde_id, p.nombre AS pmtde_nombre, n.organizacion_id, o.nombre AS organizacion_nombre FROM normativas n LEFT JOIN pmtde p ON n.pmtde_id=p.id LEFT JOIN organizaciones o ON n.organizacion_id=o.id'
+    'SELECT n.id, n.nombre, n.codigo, n.url, n.pmtde_id, p.nombre AS pmtde_nombre, n.organizacion_id, o.nombre AS organizacion_nombre, o.codigo AS organizacion_codigo FROM normativas n LEFT JOIN pmtde p ON n.pmtde_id=p.id LEFT JOIN organizaciones o ON n.organizacion_id=o.id'
   );
   const result = rows.map((r) => ({
     id: r.id,
     nombre: r.nombre,
+    codigo: r.codigo,
     url: r.url,
     pmtde: r.pmtde_id ? { id: r.pmtde_id, nombre: r.pmtde_nombre } : null,
-    organizacion: r.organizacion_id ? { id: r.organizacion_id, nombre: r.organizacion_nombre } : null,
+    organizacion: r.organizacion_id
+      ? { id: r.organizacion_id, nombre: r.organizacion_nombre, codigo: r.organizacion_codigo }
+      : null,
   }));
   res.json(result);
 });
@@ -24,12 +27,15 @@ router.post('/', async (req, res) => {
   const organizacionId =
     req.body.organizacion && req.body.organizacion.id ? req.body.organizacion.id : 1;
   const nombre = req.body.nombre || 'n/a';
+  const codigo = req.body.codigo
+    ? req.body.codigo.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 10)
+    : 'n/a';
   const url = req.body.url || 'n/a';
   const [result] = await pool.query(
-    'INSERT INTO normativas (pmtde_id, organizacion_id, nombre, url) VALUES (?, ?, ?, ?)',
-    [pmtdeId, organizacionId, nombre, url]
+    'INSERT INTO normativas (pmtde_id, organizacion_id, codigo, nombre, url) VALUES (?, ?, ?, ?, ?)',
+    [pmtdeId, organizacionId, codigo, nombre, url]
   );
-  res.json({ id: result.insertId, ...req.body });
+  res.json({ id: result.insertId, nombre, codigo, url, pmtde: req.body.pmtde, organizacion: req.body.organizacion });
 });
 
 router.put('/:id', async (req, res) => {
@@ -38,12 +44,15 @@ router.put('/:id', async (req, res) => {
   const organizacionId =
     req.body.organizacion && req.body.organizacion.id ? req.body.organizacion.id : 1;
   const nombre = req.body.nombre || 'n/a';
+  const codigo = req.body.codigo
+    ? req.body.codigo.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 10)
+    : 'n/a';
   const url = req.body.url || 'n/a';
   await pool.query(
-    'UPDATE normativas SET pmtde_id=?, organizacion_id=?, nombre=?, url=? WHERE id=?',
-    [pmtdeId, organizacionId, nombre, url, req.params.id]
+    'UPDATE normativas SET pmtde_id=?, organizacion_id=?, codigo=?, nombre=?, url=? WHERE id=?',
+    [pmtdeId, organizacionId, codigo, nombre, url, req.params.id]
   );
-  res.json({ id: parseInt(req.params.id, 10), ...req.body });
+  res.json({ id: parseInt(req.params.id, 10), nombre, codigo, url, pmtde: req.body.pmtde, organizacion: req.body.organizacion });
 });
 
 router.delete('/:id', async (req, res) => {

--- a/docs/funcional/01 Modelo de datos.md
+++ b/docs/funcional/01 Modelo de datos.md
@@ -34,6 +34,7 @@ description: "Descripción de las entidades y campos de la aplicación"
 |-------|---------------|-------------|-------------------|------------|------------------------|
 | id | INT AUTO_INCREMENT | SI |  |  |  |
 | pmtde_id | INT | SI |  | pmtde.id | SI |
+| codigo | VARCHAR(10) | SI |  |  |  |
 | nombre | VARCHAR(255) | SI |  |  |  |
 
 ## normativas
@@ -42,6 +43,7 @@ description: "Descripción de las entidades y campos de la aplicación"
 | id | INT AUTO_INCREMENT | SI |  |  |  |
 | pmtde_id | INT | SI |  | pmtde.id | SI |
 | organizacion_id | INT | SI |  | organizaciones.id | SI |
+| codigo | VARCHAR(10) | SI |  |  |  |
 | nombre | VARCHAR(255) | SI |  |  |  |
 | url | VARCHAR(255) | NO |  |  |  |
 
@@ -51,6 +53,7 @@ description: "Descripción de las entidades y campos de la aplicación"
 | id | INT AUTO_INCREMENT | SI |  |  |  |
 | pmtde_id | INT | SI |  | pmtde.id | SI |
 | normativa_id | INT | SI |  | normativas.id | SI |
+| codigo | VARCHAR(255) | SI |  |  |  |
 | titulo | VARCHAR(255) | SI |  |  |  |
 | descripcion | TEXT | NO |  |  |  |
 

--- a/docs/funcional/PMTDE/02 Organizaciones.md
+++ b/docs/funcional/PMTDE/02 Organizaciones.md
@@ -21,6 +21,7 @@ Permite mantener la maestra de organizaciones asociadas a un PMTDE. Todos los ca
 2. Elige "Crear nueva organización".
 3. Introduce:
    - PMTDE asociado (obligatorio).
+   - Código de la organización (obligatorio, alfanumérico en mayúsculas de hasta 10 caracteres).
    - Nombre de la organización (obligatorio).
 4. Confirma la acción.
 5. El sistema guarda el registro, deshabilita el botón durante el proceso y refresca la lista. Si la operación tarda más de un segundo se muestra un banner "Procesando... X seg".
@@ -63,6 +64,7 @@ Permite mantener la maestra de organizaciones asociadas a un PMTDE. Todos los ca
 **Flujo principal:**
 1. El usuario abre el submenú "Organizaciones".
 2. El sistema muestra para cada organización:
+   - Código.
    - Nombre.
    - PMTDE asociado.
 3. El usuario puede:

--- a/docs/funcional/PMTDE/03 Normativa.md
+++ b/docs/funcional/PMTDE/03 Normativa.md
@@ -22,6 +22,7 @@ Gestiona la normativa emitida por las organizaciones dentro de un PMTDE. Los cam
 3. Introduce:
    - PMTDE asociado (obligatorio).
    - Organización emisora (obligatoria).
+   - Código de la normativa (obligatorio, alfanumérico en mayúsculas de hasta 10 caracteres).
    - Nombre de la normativa (obligatorio).
    - URL de consulta (opcional).
 4. Confirma la acción.
@@ -65,6 +66,7 @@ Gestiona la normativa emitida por las organizaciones dentro de un PMTDE. Los cam
 **Flujo principal:**
 1. El usuario abre el submenú "Normativa".
 2. El sistema muestra para cada normativa:
+   - Código.
    - Nombre.
    - Organización emisora.
    - URL.

--- a/docs/funcional/PMTDE/04 Inputs.md
+++ b/docs/funcional/PMTDE/04 Inputs.md
@@ -25,10 +25,10 @@ Los inputs son las cuestiones que deben ejecutarse por exigencia de una normativ
    - Título del input (obligatorio).
    - Descripción (opcional).
 4. Confirma la acción.
-5. El sistema guarda el registro, deshabilita el botón durante el proceso y refresca la lista. Si la operación tarda más de un segundo se muestra un banner "Procesando... X seg".
+5. El sistema calcula el código concatenando "código de la organización" + "." + "código de la normativa" + "." + autonumérico (iniciando en 1 por normativa), guarda el registro, deshabilita el botón durante el proceso y refresca la lista. Si la operación tarda más de un segundo se muestra un banner "Procesando... X seg".
 
 **Postcondiciones:**
-- El input queda registrado y asociado a la normativa seleccionada.
+- El input queda registrado con su código generado y asociado a la normativa seleccionada.
 
 ---
 
@@ -65,6 +65,7 @@ Los inputs son las cuestiones que deben ejecutarse por exigencia de una normativ
 **Flujo principal:**
 1. El usuario abre el submenú "Inputs".
 2. El sistema muestra para cada input:
+   - Código.
    - Título.
    - Normativa asociada (con el nombre de la organización entre paréntesis).
    - Descripción.

--- a/frontend/js/InputsManager.js
+++ b/frontend/js/InputsManager.js
@@ -1,5 +1,6 @@
 function InputsManager({ inputs, setInputs, pmtde, normativas }) {
   const columnsConfig = [
+    { key: 'codigo', label: 'Código', render: (i) => i.codigo },
     { key: 'titulo', label: 'Título', render: (i) => i.titulo },
     {
       key: 'normativa',
@@ -61,7 +62,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
       const normText = i.normativa
         ? `${i.normativa.nombre} ${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''}`
         : '';
-      const txt = normalize(`${i.titulo} ${normText} ${i.descripcion || ''}`);
+      const txt = normalize(`${i.codigo} ${i.titulo} ${normText} ${i.descripcion || ''}`);
       const searchMatch = txt.includes(normalize(search));
       const normMatch = normFilter.length
         ? normFilter.some((n) => n.id === (i.normativa && i.normativa.id))
@@ -85,8 +86,9 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
     });
 
   const exportCSV = () => {
-    const header = ['Título', 'Normativa', 'Descripción'];
+    const header = ['Código', 'Título', 'Normativa', 'Descripción'];
     const rows = filtered.map((i) => [
+      i.codigo,
       i.titulo,
       i.normativa
         ? `${i.normativa.nombre} (${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`
@@ -103,7 +105,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
     let y = 20;
     filtered.forEach((i) => {
       doc.text(
-        `${i.titulo} - ${i.normativa ? i.normativa.nombre : ''} (${i.normativa && i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`,
+        `${i.codigo} - ${i.titulo} - ${i.normativa ? i.normativa.nombre : ''} (${i.normativa && i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`,
         10,
         y
       );
@@ -207,7 +209,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
           {filtered.map((i) => (
             <Card key={i.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{i.titulo}</Typography>
+                <Typography variant="h6">{i.codigo} - {i.titulo}</Typography>
                 <Typography variant="body2">
                   {i.normativa
                     ? `${i.normativa.nombre} (${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`

--- a/frontend/js/NormativasManager.js
+++ b/frontend/js/NormativasManager.js
@@ -1,5 +1,6 @@
 function NormativasManager({ normativas, setNormativas, pmtde, organizaciones }) {
   const columnsConfig = [
+    { key: 'codigo', label: 'Código', render: (n) => n.codigo },
     { key: 'nombre', label: 'Nombre', render: (n) => n.nombre },
     {
       key: 'organizacion',
@@ -10,7 +11,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
   ];
   const { columns, openSelector, selector } = useColumnPreferences('normativas', columnsConfig);
   const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [current, setCurrent] = React.useState({ nombre: '', pmtde: null, organizacion: null, url: '' });
+  const [current, setCurrent] = React.useState({ codigo: '', nombre: '', pmtde: null, organizacion: null, url: '' });
   const [view, setView] = React.useState('table');
   const [filterOpen, setFilterOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
@@ -20,7 +21,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
   const { busy, seconds, perform } = useProcessing();
 
   const openNew = () => {
-    setCurrent({ nombre: '', pmtde: null, organizacion: null, url: '' });
+    setCurrent({ codigo: '', nombre: '', pmtde: null, organizacion: null, url: '' });
     setDialogOpen(true);
   };
 
@@ -49,7 +50,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
 
   const filtered = normativas
     .filter((n) => {
-      const txt = normalize(`${n.nombre} ${n.organizacion ? n.organizacion.nombre : ''} ${n.url}`);
+      const txt = normalize(`${n.codigo} ${n.nombre} ${n.organizacion ? n.organizacion.nombre : ''} ${n.url}`);
       const searchMatch = txt.includes(normalize(search));
       const orgMatch = orgFilter.length
         ? orgFilter.some((o) => o.id === (n.organizacion && n.organizacion.id))
@@ -71,8 +72,8 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
     });
 
   const exportCSV = () => {
-    const header = ['Nombre', 'Organización', 'URL'];
-    const rows = filtered.map((n) => [n.nombre, n.organizacion ? n.organizacion.nombre : '', n.url]);
+    const header = ['Código', 'Nombre', 'Organización', 'URL'];
+    const rows = filtered.map((n) => [n.codigo, n.nombre, n.organizacion ? n.organizacion.nombre : '', n.url]);
     exportToCSV(header, rows, 'Normativas');
   };
 
@@ -82,7 +83,11 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
     doc.text('Normativas', 10, 10);
     let y = 20;
     filtered.forEach((n) => {
-      doc.text(`${n.nombre} - ${n.organizacion ? n.organizacion.nombre : ''} - ${n.url}`, 10, y);
+      doc.text(
+        `${n.codigo} - ${n.nombre} - ${n.organizacion ? n.organizacion.nombre : ''} - ${n.url}`,
+        10,
+        y
+      );
       y += 10;
     });
     doc.save(`${formatDate()} Normativas.pdf`);
@@ -181,9 +186,9 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
           {filtered.map((n) => (
             <Card key={n.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{n.nombre}</Typography>
-                <Typography variant="body2">{n.organizacion ? n.organizacion.nombre : ''}</Typography>
-                <Typography variant="body2">{n.url}</Typography>
+            <Typography variant="h6">{n.codigo} - {n.nombre}</Typography>
+            <Typography variant="body2">{n.organizacion ? n.organizacion.nombre : ''}</Typography>
+            <Typography variant="body2">{n.url}</Typography>
                 <Box sx={{ mt: 1 }}>
                   <Tooltip title="Editar">
                     <IconButton onClick={() => openEdit(n)} disabled={busy}>
@@ -205,6 +210,19 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar normativa' : 'Nueva normativa'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            label="Código*"
+            value={current.codigo}
+            onChange={(e) =>
+              setCurrent({
+                ...current,
+                codigo: e.target.value
+                  .toUpperCase()
+                  .replace(/[^A-Z0-9]/g, '')
+                  .slice(0, 10),
+              })
+            }
+          />
           <TextField
             label="Nombre*"
             value={current.nombre}

--- a/frontend/js/OrganizacionesManager.js
+++ b/frontend/js/OrganizacionesManager.js
@@ -1,5 +1,6 @@
 function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
   const columnsConfig = [
+    { key: 'codigo', label: 'Código', render: (o) => o.codigo },
     { key: 'nombre', label: 'Nombre', render: (o) => o.nombre },
     {
       key: 'pmtde',
@@ -9,7 +10,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
   ];
   const { columns, openSelector, selector } = useColumnPreferences('organizaciones', columnsConfig);
   const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [current, setCurrent] = React.useState({ nombre: '', pmtde: null });
+  const [current, setCurrent] = React.useState({ codigo: '', nombre: '', pmtde: null });
   const [view, setView] = React.useState('table');
   const [filterOpen, setFilterOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
@@ -19,7 +20,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
   const { busy, seconds, perform } = useProcessing();
 
   const openNew = () => {
-    setCurrent({ nombre: '', pmtde: null });
+    setCurrent({ codigo: '', nombre: '', pmtde: null });
     setDialogOpen(true);
   };
 
@@ -48,7 +49,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
 
   const filtered = organizaciones
     .filter((o) => {
-      const txt = normalize(`${o.nombre} ${o.pmtde ? o.pmtde.nombre : ''}`);
+      const txt = normalize(`${o.codigo} ${o.nombre} ${o.pmtde ? o.pmtde.nombre : ''}`);
       const searchMatch = txt.includes(normalize(search));
       const pmtdeMatch = pmtdeFilter.length
         ? pmtdeFilter.some((p) => p.id === (o.pmtde && o.pmtde.id))
@@ -70,8 +71,8 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
     });
 
   const exportCSV = () => {
-    const header = ['Nombre', 'PMTDE'];
-    const rows = filtered.map((o) => [o.nombre, o.pmtde ? o.pmtde.nombre : '']);
+    const header = ['Código', 'Nombre', 'PMTDE'];
+    const rows = filtered.map((o) => [o.codigo, o.nombre, o.pmtde ? o.pmtde.nombre : '']);
     exportToCSV(header, rows, 'Organizaciones');
   };
 
@@ -81,7 +82,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
     doc.text('Organizaciones', 10, 10);
     let y = 20;
     filtered.forEach((o) => {
-      doc.text(`${o.nombre} - ${o.pmtde ? o.pmtde.nombre : ''}`, 10, y);
+      doc.text(`${o.codigo} - ${o.nombre} - ${o.pmtde ? o.pmtde.nombre : ''}`, 10, y);
       y += 10;
     });
     doc.save(`${formatDate()} Organizaciones.pdf`);
@@ -176,8 +177,8 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
           {filtered.map((o) => (
             <Card key={o.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{o.nombre}</Typography>
-                <Typography variant="body2">{o.pmtde ? o.pmtde.nombre : ''}</Typography>
+            <Typography variant="h6">{o.codigo} - {o.nombre}</Typography>
+            <Typography variant="body2">{o.pmtde ? o.pmtde.nombre : ''}</Typography>
                 <Box sx={{ mt: 1 }}>
                   <Tooltip title="Editar">
                     <IconButton onClick={() => openEdit(o)} disabled={busy}>
@@ -199,6 +200,19 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar organización' : 'Nueva organización'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            label="Código*"
+            value={current.codigo}
+            onChange={(e) =>
+              setCurrent({
+                ...current,
+                codigo: e.target.value
+                  .toUpperCase()
+                  .replace(/[^A-Z0-9]/g, '')
+                  .slice(0, 10),
+              })
+            }
+          />
           <TextField
             label="Nombre*"
             value={current.nombre}


### PR DESCRIPTION
## Summary
- add codigo columns for organizaciones, normativas and inputs
- generate input codes from organization and normativa codes
- document new codigo fields in use cases and data model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a79e931d1c8331a3842c9b01f63d00