### PR TITLE
feat: add codes for organizations, norms and inputs

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -85,19 +85,29 @@ async function initDb() {
       id INT AUTO_INCREMENT PRIMARY KEY,
       pmtde_id INT NOT NULL,
       nombre VARCHAR(255) NOT NULL,
+      codigo VARCHAR(10) NOT NULL,
       FOREIGN KEY (pmtde_id) REFERENCES pmtde(id) ON DELETE CASCADE
     )`
   );
 
+  await pool.query(
+    "ALTER TABLE organizaciones ADD COLUMN IF NOT EXISTS codigo VARCHAR(10) NOT NULL"
+  );
+  await pool.query(
+    "UPDATE organizaciones SET codigo='NA' WHERE codigo IS NULL OR codigo=''"
+  );
   const [defaultOrg] = await pool.query('SELECT id FROM organizaciones WHERE id=1');
   if (defaultOrg.length === 0) {
-    await pool.query("INSERT INTO organizaciones (id, pmtde_id, nombre) VALUES (1, 1, 'n/a')");
+    await pool.query(
+      "INSERT INTO organizaciones (id, pmtde_id, nombre, codigo) VALUES (1, 1, 'n/a', 'NA')"
+    );
   }
   await pool.query(
     `CREATE TABLE IF NOT EXISTS normativas (
       id INT AUTO_INCREMENT PRIMARY KEY,
       pmtde_id INT NOT NULL,
       organizacion_id INT NOT NULL,
+      codigo VARCHAR(10) NOT NULL,
       nombre VARCHAR(255) NOT NULL,
       tipo ENUM('Normativa','Estrategia','Plan','Programa','Otros') NOT NULL,
       url VARCHAR(255),
@@ -109,12 +119,18 @@ async function initDb() {
   await pool.query(
     "ALTER TABLE normativas ADD COLUMN IF NOT EXISTS tipo ENUM('Normativa','Estrategia','Plan','Programa','Otros') NOT NULL"
   );
+  await pool.query(
+    "ALTER TABLE normativas ADD COLUMN IF NOT EXISTS codigo VARCHAR(10) NOT NULL"
+  );
   await pool.query("UPDATE normativas SET tipo='Normativa' WHERE tipo IS NULL");
+  await pool.query(
+    "UPDATE normativas SET codigo='NA' WHERE codigo IS NULL OR codigo=''"
+  );
 
   const [defaultNorm] = await pool.query('SELECT id FROM normativas WHERE id=1');
   if (defaultNorm.length === 0) {
     await pool.query(
-      "INSERT INTO normativas (id, pmtde_id, organizacion_id, nombre, url, tipo) VALUES (1, 1, 1, 'n/a', 'n/a', 'Normativa')"
+      "INSERT INTO normativas (id, pmtde_id, organizacion_id, codigo, nombre, url, tipo) VALUES (1, 1, 1, 'NA', 'n/a', 'n/a', 'Normativa')"
     );
   }
 
@@ -124,6 +140,7 @@ async function initDb() {
       id INT AUTO_INCREMENT PRIMARY KEY,
       pmtde_id INT NOT NULL,
       normativa_id INT NOT NULL,
+      codigo VARCHAR(30) NOT NULL,
       titulo VARCHAR(255) NOT NULL,
       descripcion TEXT,
       FOREIGN KEY (pmtde_id) REFERENCES pmtde(id) ON DELETE CASCADE,
@@ -133,10 +150,16 @@ async function initDb() {
   await pool.query(
     "ALTER TABLE inputs MODIFY COLUMN descripcion TEXT"
   );
+  await pool.query(
+    "ALTER TABLE inputs ADD COLUMN IF NOT EXISTS codigo VARCHAR(30) NOT NULL"
+  );
+  await pool.query(
+    "UPDATE inputs SET codigo='NA' WHERE codigo IS NULL OR codigo=''"
+  );
   const [defaultInput] = await pool.query('SELECT id FROM inputs WHERE id=1');
   if (defaultInput.length === 0) {
     await pool.query(
-      "INSERT INTO inputs (id, pmtde_id, normativa_id, titulo, descripcion) VALUES (1, 1, 1, 'n/a', 'n/a')"
+      "INSERT INTO inputs (id, pmtde_id, normativa_id, codigo, titulo, descripcion) VALUES (1, 1, 1, 'NA.NA.1', 'n/a', 'n/a')"
     );
   }
 

--- a/backend/routes/inputs.js
+++ b/backend/routes/inputs.js
@@ -6,10 +6,11 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   const pool = getDb();
   const [rows] = await pool.query(
-    "SELECT i.id, i.titulo, i.descripcion, i.pmtde_id, p.nombre AS pmtde_nombre, i.normativa_id, n.nombre AS normativa_nombre, n.tipo AS normativa_tipo, n.organizacion_id, o.nombre AS organizacion_nombre FROM inputs i LEFT JOIN pmtde p ON i.pmtde_id=p.id LEFT JOIN normativas n ON i.normativa_id=n.id LEFT JOIN organizaciones o ON n.organizacion_id=o.id"
+    "SELECT i.id, i.codigo, i.titulo, i.descripcion, i.pmtde_id, p.nombre AS pmtde_nombre, i.normativa_id, n.nombre AS normativa_nombre, n.codigo AS normativa_codigo, n.tipo AS normativa_tipo, n.organizacion_id, o.nombre AS organizacion_nombre, o.codigo AS organizacion_codigo FROM inputs i LEFT JOIN pmtde p ON i.pmtde_id=p.id LEFT JOIN normativas n ON i.normativa_id=n.id LEFT JOIN organizaciones o ON n.organizacion_id=o.id"
   );
   const result = rows.map((r) => ({
     id: r.id,
+    codigo: r.codigo,
     titulo: r.titulo,
     descripcion: r.descripcion,
     pmtde: r.pmtde_id ? { id: r.pmtde_id, nombre: r.pmtde_nombre } : null,
@@ -31,11 +32,21 @@ router.post('/', async (req, res) => {
   const normativaId = req.body.normativa && req.body.normativa.id ? req.body.normativa.id : 1;
   const titulo = req.body.titulo || 'n/a';
   const descripcion = req.body.descripcion || 'n/a';
-  const [result] = await pool.query(
-    'INSERT INTO inputs (pmtde_id, normativa_id, titulo, descripcion) VALUES (?, ?, ?, ?)',
-    [pmtdeId, normativaId, titulo, descripcion]
+  const [[codes]] = await pool.query(
+    'SELECT n.codigo AS ncod, o.codigo AS ocod FROM normativas n JOIN organizaciones o ON n.organizacion_id=o.id WHERE n.id=?',
+    [normativaId]
   );
-  res.json({ id: result.insertId, ...req.body });
+  const [[count]] = await pool.query(
+    'SELECT COUNT(*) AS c FROM inputs WHERE normativa_id=?',
+    [normativaId]
+  );
+  const auto = count.c + 1;
+  const codigo = `${codes.ocod}.${codes.ncod}.${auto}`;
+  const [result] = await pool.query(
+    'INSERT INTO inputs (pmtde_id, normativa_id, codigo, titulo, descripcion) VALUES (?, ?, ?, ?, ?)',
+    [pmtdeId, normativaId, codigo, titulo, descripcion]
+  );
+  res.json({ id: result.insertId, codigo, ...req.body });
 });
 
 router.put('/:id', async (req, res) => {
@@ -44,11 +55,21 @@ router.put('/:id', async (req, res) => {
   const normativaId = req.body.normativa && req.body.normativa.id ? req.body.normativa.id : 1;
   const titulo = req.body.titulo || 'n/a';
   const descripcion = req.body.descripcion || 'n/a';
-  await pool.query(
-    'UPDATE inputs SET pmtde_id=?, normativa_id=?, titulo=?, descripcion=? WHERE id=?',
-    [pmtdeId, normativaId, titulo, descripcion, req.params.id]
+  const [[codes]] = await pool.query(
+    'SELECT n.codigo AS ncod, o.codigo AS ocod FROM normativas n JOIN organizaciones o ON n.organizacion_id=o.id WHERE n.id=?',
+    [normativaId]
   );
-  res.json({ id: parseInt(req.params.id, 10), ...req.body });
+  const [[count]] = await pool.query(
+    'SELECT COUNT(*) AS c FROM inputs WHERE normativa_id=? AND id<>?',
+    [normativaId, req.params.id]
+  );
+  const auto = count.c + 1;
+  const codigo = `${codes.ocod}.${codes.ncod}.${auto}`;
+  await pool.query(
+    'UPDATE inputs SET pmtde_id=?, normativa_id=?, codigo=?, titulo=?, descripcion=? WHERE id=?',
+    [pmtdeId, normativaId, codigo, titulo, descripcion, req.params.id]
+  );
+  res.json({ id: parseInt(req.params.id, 10), codigo, ...req.body });
 });
 
 router.delete('/:id', async (req, res) => {

--- a/backend/routes/normativas.js
+++ b/backend/routes/normativas.js
@@ -6,11 +6,12 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   const pool = getDb();
   const [rows] = await pool.query(
-    "SELECT n.id, n.nombre, n.tipo, n.url, n.pmtde_id, p.nombre AS pmtde_nombre, n.organizacion_id, o.nombre AS organizacion_nombre FROM normativas n LEFT JOIN pmtde p ON n.pmtde_id=p.id LEFT JOIN organizaciones o ON n.organizacion_id=o.id"
+    "SELECT n.id, n.nombre, n.codigo, n.tipo, n.url, n.pmtde_id, p.nombre AS pmtde_nombre, n.organizacion_id, o.nombre AS organizacion_nombre FROM normativas n LEFT JOIN pmtde p ON n.pmtde_id=p.id LEFT JOIN organizaciones o ON n.organizacion_id=o.id"
   );
   const result = rows.map((r) => ({
     id: r.id,
     nombre: r.nombre,
+    codigo: r.codigo,
     tipo: r.tipo,
     url: r.url,
     pmtde: r.pmtde_id ? { id: r.pmtde_id, nombre: r.pmtde_nombre } : null,
@@ -27,9 +28,10 @@ router.post('/', async (req, res) => {
   const nombre = req.body.nombre || 'n/a';
   const tipo = req.body.tipo || 'Normativa';
   const url = req.body.url || 'n/a';
+  const codigo = (req.body.codigo || 'NA').toUpperCase().replace(/[^A-Z0-9]/g, '').substring(0, 10);
   const [result] = await pool.query(
-    'INSERT INTO normativas (pmtde_id, organizacion_id, nombre, tipo, url) VALUES (?, ?, ?, ?, ?)',
-    [pmtdeId, organizacionId, nombre, tipo, url]
+    'INSERT INTO normativas (pmtde_id, organizacion_id, codigo, nombre, tipo, url) VALUES (?, ?, ?, ?, ?, ?)',
+    [pmtdeId, organizacionId, codigo, nombre, tipo, url]
   );
   res.json({ id: result.insertId, ...req.body });
 });
@@ -42,9 +44,10 @@ router.put('/:id', async (req, res) => {
   const nombre = req.body.nombre || 'n/a';
   const tipo = req.body.tipo || 'Normativa';
   const url = req.body.url || 'n/a';
+  const codigo = (req.body.codigo || 'NA').toUpperCase().replace(/[^A-Z0-9]/g, '').substring(0, 10);
   await pool.query(
-    'UPDATE normativas SET pmtde_id=?, organizacion_id=?, nombre=?, tipo=?, url=? WHERE id=?',
-    [pmtdeId, organizacionId, nombre, tipo, url, req.params.id]
+    'UPDATE normativas SET pmtde_id=?, organizacion_id=?, codigo=?, nombre=?, tipo=?, url=? WHERE id=?',
+    [pmtdeId, organizacionId, codigo, nombre, tipo, url, req.params.id]
   );
   res.json({ id: parseInt(req.params.id, 10), ...req.body });
 });

--- a/backend/routes/organizaciones.js
+++ b/backend/routes/organizaciones.js
@@ -6,11 +6,12 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   const pool = getDb();
   const [rows] = await pool.query(
-    'SELECT o.id, o.nombre, o.pmtde_id, p.nombre AS pmtde_nombre FROM organizaciones o LEFT JOIN pmtde p ON o.pmtde_id=p.id'
+    'SELECT o.id, o.nombre, o.codigo, o.pmtde_id, p.nombre AS pmtde_nombre FROM organizaciones o LEFT JOIN pmtde p ON o.pmtde_id=p.id'
   );
   const result = rows.map((r) => ({
     id: r.id,
     nombre: r.nombre,
+    codigo: r.codigo,
     pmtde: r.pmtde_id ? { id: r.pmtde_id, nombre: r.pmtde_nombre } : null,
   }));
   res.json(result);
@@ -20,9 +21,10 @@ router.post('/', async (req, res) => {
   const pool = getDb();
   const pmtdeId = req.body.pmtde && req.body.pmtde.id ? req.body.pmtde.id : 1;
   const nombre = req.body.nombre || 'n/a';
+  const codigo = (req.body.codigo || 'NA').toUpperCase().replace(/[^A-Z0-9]/g, '').substring(0, 10);
   const [result] = await pool.query(
-    'INSERT INTO organizaciones (pmtde_id, nombre) VALUES (?, ?)',
-    [pmtdeId, nombre]
+    'INSERT INTO organizaciones (pmtde_id, nombre, codigo) VALUES (?, ?, ?)',
+    [pmtdeId, nombre, codigo]
   );
   res.json({ id: result.insertId, ...req.body });
 });
@@ -31,9 +33,10 @@ router.put('/:id', async (req, res) => {
   const pool = getDb();
   const pmtdeId = req.body.pmtde && req.body.pmtde.id ? req.body.pmtde.id : 1;
   const nombre = req.body.nombre || 'n/a';
+  const codigo = (req.body.codigo || 'NA').toUpperCase().replace(/[^A-Z0-9]/g, '').substring(0, 10);
   await pool.query(
-    'UPDATE organizaciones SET pmtde_id=?, nombre=? WHERE id=?',
-    [pmtdeId, nombre, req.params.id]
+    'UPDATE organizaciones SET pmtde_id=?, nombre=?, codigo=? WHERE id=?',
+    [pmtdeId, nombre, codigo, req.params.id]
   );
   res.json({ id: parseInt(req.params.id, 10), ...req.body });
 });

--- a/docs/funcional/01 Modelo de datos.md
+++ b/docs/funcional/01 Modelo de datos.md
@@ -35,6 +35,7 @@ description: "Descripción de las entidades y campos de la aplicación"
 | id | INT AUTO_INCREMENT | SI |  |  |  |
 | pmtde_id | INT | SI |  | pmtde.id | SI |
 | nombre | VARCHAR(255) | SI |  |  |  |
+| codigo | VARCHAR(10) | SI |  |  |  |
 
 ## normativas
 | Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
@@ -42,6 +43,7 @@ description: "Descripción de las entidades y campos de la aplicación"
 | id | INT AUTO_INCREMENT | SI |  |  |  |
 | pmtde_id | INT | SI |  | pmtde.id | SI |
 | organizacion_id | INT | SI |  | organizaciones.id | SI |
+| codigo | VARCHAR(10) | SI |  |  |  |
 | nombre | VARCHAR(255) | SI |  |  |  |
 | tipo | ENUM('Normativa','Estrategia','Plan','Programa','Otros') | SI |  |  |  |
 | url | VARCHAR(255) | NO |  |  |  |
@@ -52,6 +54,7 @@ description: "Descripción de las entidades y campos de la aplicación"
 | id | INT AUTO_INCREMENT | SI |  |  |  |
 | pmtde_id | INT | SI |  | pmtde.id | SI |
 | normativa_id | INT | SI |  | normativas.id | SI |
+| codigo | VARCHAR(30) | SI |  |  |  |
 | titulo | VARCHAR(255) | SI |  |  |  |
 | descripcion | TEXT | NO |  |  |  |
 

--- a/docs/funcional/PMTDE/02 Organizaciones.md
+++ b/docs/funcional/PMTDE/02 Organizaciones.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: Organizaciones
 
 ## Contexto
-Permite mantener la maestra de organizaciones asociadas a un PMTDE. Todos los campos obligatorios se marcan visualmente con un asterisco.
+Permite mantener la maestra de organizaciones asociadas a un PMTDE. Todos los campos obligatorios se marcan visualmente con un asterisco. Cada organización dispone de un código alfanumérico en mayúsculas de hasta 10 caracteres definido por el usuario.
 
 ---
 
@@ -20,6 +20,7 @@ Permite mantener la maestra de organizaciones asociadas a un PMTDE. Todos los ca
 1. El usuario accede al submenú "Organizaciones".
 2. Elige "Crear nueva organización".
 3. Introduce:
+   - Código de la organización (obligatorio, alfanumérico en mayúsculas, máximo 10 caracteres).
    - PMTDE asociado (obligatorio).
    - Nombre de la organización (obligatorio).
 4. Confirma la acción.
@@ -63,6 +64,7 @@ Permite mantener la maestra de organizaciones asociadas a un PMTDE. Todos los ca
 **Flujo principal:**
 1. El usuario abre el submenú "Organizaciones".
 2. El sistema muestra para cada organización:
+   - Código.
    - Nombre.
    - PMTDE asociado.
 3. El usuario puede:

--- a/docs/funcional/PMTDE/03 Normativa.md
+++ b/docs/funcional/PMTDE/03 Normativa.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: Normativa
 
 ## Contexto
-Gestiona la normativa emitida por las organizaciones dentro de un PMTDE. Los campos obligatorios aparecen marcados con un asterisco.
+Gestiona la normativa emitida por las organizaciones dentro de un PMTDE. Los campos obligatorios aparecen marcados con un asterisco. Cada normativa incluye un código alfanumérico en mayúsculas de hasta 10 caracteres definido por el usuario.
 
 ---
 
@@ -20,6 +20,7 @@ Gestiona la normativa emitida por las organizaciones dentro de un PMTDE. Los cam
 1. El usuario accede al submenú "Normativa".
 2. Elige "Crear nueva normativa".
 3. Introduce:
+   - Código de la normativa (obligatorio, alfanumérico en mayúsculas, máximo 10 caracteres).
    - PMTDE asociado (obligatorio).
    - Organización emisora (obligatoria).
    - Tipo de normativa (obligatorio).
@@ -66,6 +67,7 @@ Gestiona la normativa emitida por las organizaciones dentro de un PMTDE. Los cam
 **Flujo principal:**
 1. El usuario abre el submenú "Normativa".
 2. El sistema muestra para cada normativa:
+   - Código.
    - Nombre.
    - Tipo.
    - Organización emisora.

--- a/docs/funcional/PMTDE/04 Inputs.md
+++ b/docs/funcional/PMTDE/04 Inputs.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: Inputs
 
 ## Contexto
-Los inputs son las cuestiones que deben ejecutarse por exigencia de una normativa. Su mantenimiento permite gestionarlos como menú del PMTDE.
+Los inputs son las cuestiones que deben ejecutarse por exigencia de una normativa. Su mantenimiento permite gestionarlos como menú del PMTDE. Cada input posee un código generado automáticamente combinando el código de la organización, el código de la normativa y un autonumérico por normativa.
 
 ---
 
@@ -24,6 +24,7 @@ Los inputs son las cuestiones que deben ejecutarse por exigencia de una normativ
    - Normativa asociada (obligatoria). En el combo de selección se muestra el nombre de la normativa seguido entre paréntesis del nombre de la organización, permitiendo búsqueda por ambos valores.
    - Título del input (obligatorio).
    - Descripción (opcional).
+   - El código se calcula automáticamente.
 4. Confirma la acción.
 5. El sistema guarda el registro, deshabilita el botón durante el proceso y refresca la lista. Si la operación tarda más de un segundo se muestra un banner "Procesando... X seg".
 
@@ -65,13 +66,14 @@ Los inputs son las cuestiones que deben ejecutarse por exigencia de una normativ
 **Flujo principal:**
 1. El usuario abre el submenú "Inputs".
 2. El sistema muestra para cada input:
+   - Código.
    - Título.
    - Normativa asociada (con el nombre de la organización entre paréntesis).
    - Descripción.
 3. El usuario puede:
    - Cambiar entre vista tabla o cards.
    - Ordenar por cualquier columna.
-   - Seleccionar las columnas visibles (Título, Normativa, Descripción).
+   - Seleccionar las columnas visibles (Código, Título, Normativa, Descripción).
    - Abrir la sección de filtros para buscar texto, filtrar por normativa y reiniciar filtros.
    - Exportar la lista a CSV (separador ";" y fechas entre comillas) o PDF.
 

--- a/frontend/js/InputsManager.js
+++ b/frontend/js/InputsManager.js
@@ -1,5 +1,6 @@
 function InputsManager({ inputs, setInputs, pmtde, normativas }) {
   const columnsConfig = [
+    { key: 'codigo', label: 'Código', render: (i) => i.codigo },
     { key: 'titulo', label: 'Título', render: (i) => i.titulo },
     {
       key: 'normativa',
@@ -19,7 +20,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
   ];
   const { columns, openSelector, selector } = useColumnPreferences('inputs', columnsConfig);
   const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [current, setCurrent] = React.useState({ pmtde: null, normativa: null, titulo: '', descripcion: '' });
+  const [current, setCurrent] = React.useState({ codigo: '', pmtde: null, normativa: null, titulo: '', descripcion: '' });
   const [view, setView] = React.useState('table');
   const [filterOpen, setFilterOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
@@ -29,7 +30,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
   const { busy, seconds, perform } = useProcessing();
 
   const openNew = () => {
-    setCurrent({ pmtde: null, normativa: null, titulo: '', descripcion: '' });
+    setCurrent({ codigo: '', pmtde: null, normativa: null, titulo: '', descripcion: '' });
     setDialogOpen(true);
   };
 
@@ -61,7 +62,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
       const normText = i.normativa
         ? `${i.normativa.nombre} ${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''}`
         : '';
-      const txt = normalize(`${i.titulo} ${normText} ${i.descripcion || ''}`);
+      const txt = normalize(`${i.codigo} ${i.titulo} ${normText} ${i.descripcion || ''}`);
       const searchMatch = txt.includes(normalize(search));
       const normMatch = normFilter.length
         ? normFilter.some((n) => n.id === (i.normativa && i.normativa.id))
@@ -85,8 +86,9 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
     });
 
   const exportCSV = () => {
-    const header = ['Título', 'Normativa', 'Descripción'];
+    const header = ['Código', 'Título', 'Normativa', 'Descripción'];
     const rows = filtered.map((i) => [
+      i.codigo,
       i.titulo,
       i.normativa
         ? `${i.normativa.nombre} (${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`
@@ -103,7 +105,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
     let y = 20;
     filtered.forEach((i) => {
       doc.text(
-        `${i.titulo} - ${i.normativa ? i.normativa.nombre : ''} (${i.normativa && i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`,
+        `${i.codigo} - ${i.titulo} - ${i.normativa ? i.normativa.nombre : ''} (${i.normativa && i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`,
         10,
         y
       );
@@ -207,7 +209,8 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
           {filtered.map((i) => (
             <Card key={i.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{i.titulo}</Typography>
+                <Typography variant="h6">{i.codigo}</Typography>
+                <Typography variant="body2">{i.titulo}</Typography>
                 <Typography variant="body2">
                   {i.normativa
                     ? `${i.normativa.nombre} (${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`
@@ -237,6 +240,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar input' : 'Nuevo input'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="Código" value={current.codigo} disabled />
           <Autocomplete
             options={pmtde}
             getOptionLabel={(p) => p.nombre}

--- a/frontend/js/NormativasManager.js
+++ b/frontend/js/NormativasManager.js
@@ -1,5 +1,6 @@
 function NormativasManager({ normativas, setNormativas, pmtde, organizaciones }) {
   const columnsConfig = [
+    { key: 'codigo', label: 'Código', render: (n) => n.codigo },
     { key: 'nombre', label: 'Nombre', render: (n) => n.nombre },
     { key: 'tipo', label: 'Tipo', render: (n) => n.tipo },
     {
@@ -12,7 +13,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
   const tipoOptions = ['Normativa', 'Estrategia', 'Plan', 'Programa', 'Otros'];
   const { columns, openSelector, selector } = useColumnPreferences('normativas', columnsConfig);
   const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [current, setCurrent] = React.useState({ nombre: '', tipo: 'Normativa', pmtde: null, organizacion: null, url: '' });
+  const [current, setCurrent] = React.useState({ codigo: '', nombre: '', tipo: 'Normativa', pmtde: null, organizacion: null, url: '' });
   const [view, setView] = React.useState('table');
   const [filterOpen, setFilterOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
@@ -23,7 +24,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
   const { busy, seconds, perform } = useProcessing();
 
   const openNew = () => {
-    setCurrent({ nombre: '', tipo: 'Normativa', pmtde: null, organizacion: null, url: '' });
+    setCurrent({ codigo: '', nombre: '', tipo: 'Normativa', pmtde: null, organizacion: null, url: '' });
     setDialogOpen(true);
   };
 
@@ -52,7 +53,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
 
   const filtered = normativas
     .filter((n) => {
-      const txt = normalize(`${n.nombre} ${n.tipo} ${n.organizacion ? n.organizacion.nombre : ''} ${n.url}`);
+      const txt = normalize(`${n.codigo} ${n.nombre} ${n.tipo} ${n.organizacion ? n.organizacion.nombre : ''} ${n.url}`);
       const searchMatch = txt.includes(normalize(search));
       const orgMatch = orgFilter.length
         ? orgFilter.some((o) => o.id === (n.organizacion && n.organizacion.id))
@@ -75,8 +76,8 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
     });
 
   const exportCSV = () => {
-    const header = ['Nombre', 'Tipo', 'Organización', 'URL'];
-    const rows = filtered.map((n) => [n.nombre, n.tipo, n.organizacion ? n.organizacion.nombre : '', n.url]);
+    const header = ['Código', 'Nombre', 'Tipo', 'Organización', 'URL'];
+    const rows = filtered.map((n) => [n.codigo, n.nombre, n.tipo, n.organizacion ? n.organizacion.nombre : '', n.url]);
     exportToCSV(header, rows, 'Normativas');
   };
 
@@ -86,7 +87,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
     doc.text('Normativas', 10, 10);
     let y = 20;
     filtered.forEach((n) => {
-      doc.text(`${n.nombre} - ${n.tipo} - ${n.organizacion ? n.organizacion.nombre : ''} - ${n.url}`, 10, y);
+      doc.text(`${n.codigo} - ${n.nombre} - ${n.tipo} - ${n.organizacion ? n.organizacion.nombre : ''} - ${n.url}`, 10, y);
       y += 10;
     });
     doc.save(`${formatDate()} Normativas.pdf`);
@@ -193,7 +194,8 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
           {filtered.map((n) => (
             <Card key={n.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{n.nombre}</Typography>
+                <Typography variant="h6">{n.codigo}</Typography>
+                <Typography variant="body2">{n.nombre}</Typography>
                 <Typography variant="body2">{n.tipo}</Typography>
                 <Typography variant="body2">{n.organizacion ? n.organizacion.nombre : ''}</Typography>
                 <Typography variant="body2">{n.url}</Typography>
@@ -218,6 +220,14 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar normativa' : 'Nueva normativa'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            label="Código*"
+            value={current.codigo}
+            inputProps={{ maxLength: 10, style: { textTransform: 'uppercase' } }}
+            onChange={(e) =>
+              setCurrent({ ...current, codigo: e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '') })
+            }
+          />
           <TextField
             label="Nombre*"
             value={current.nombre}

--- a/frontend/js/OrganizacionesManager.js
+++ b/frontend/js/OrganizacionesManager.js
@@ -1,5 +1,6 @@
 function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
   const columnsConfig = [
+    { key: 'codigo', label: 'Código', render: (o) => o.codigo },
     { key: 'nombre', label: 'Nombre', render: (o) => o.nombre },
     {
       key: 'pmtde',
@@ -9,7 +10,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
   ];
   const { columns, openSelector, selector } = useColumnPreferences('organizaciones', columnsConfig);
   const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [current, setCurrent] = React.useState({ nombre: '', pmtde: null });
+  const [current, setCurrent] = React.useState({ codigo: '', nombre: '', pmtde: null });
   const [view, setView] = React.useState('table');
   const [filterOpen, setFilterOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
@@ -19,7 +20,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
   const { busy, seconds, perform } = useProcessing();
 
   const openNew = () => {
-    setCurrent({ nombre: '', pmtde: null });
+    setCurrent({ codigo: '', nombre: '', pmtde: null });
     setDialogOpen(true);
   };
 
@@ -48,7 +49,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
 
   const filtered = organizaciones
     .filter((o) => {
-      const txt = normalize(`${o.nombre} ${o.pmtde ? o.pmtde.nombre : ''}`);
+      const txt = normalize(`${o.codigo} ${o.nombre} ${o.pmtde ? o.pmtde.nombre : ''}`);
       const searchMatch = txt.includes(normalize(search));
       const pmtdeMatch = pmtdeFilter.length
         ? pmtdeFilter.some((p) => p.id === (o.pmtde && o.pmtde.id))
@@ -70,8 +71,8 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
     });
 
   const exportCSV = () => {
-    const header = ['Nombre', 'PMTDE'];
-    const rows = filtered.map((o) => [o.nombre, o.pmtde ? o.pmtde.nombre : '']);
+    const header = ['Código', 'Nombre', 'PMTDE'];
+    const rows = filtered.map((o) => [o.codigo, o.nombre, o.pmtde ? o.pmtde.nombre : '']);
     exportToCSV(header, rows, 'Organizaciones');
   };
 
@@ -81,7 +82,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
     doc.text('Organizaciones', 10, 10);
     let y = 20;
     filtered.forEach((o) => {
-      doc.text(`${o.nombre} - ${o.pmtde ? o.pmtde.nombre : ''}`, 10, y);
+      doc.text(`${o.codigo} - ${o.nombre} - ${o.pmtde ? o.pmtde.nombre : ''}`, 10, y);
       y += 10;
     });
     doc.save(`${formatDate()} Organizaciones.pdf`);
@@ -176,7 +177,8 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
           {filtered.map((o) => (
             <Card key={o.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{o.nombre}</Typography>
+                <Typography variant="h6">{o.codigo}</Typography>
+                <Typography variant="body2">{o.nombre}</Typography>
                 <Typography variant="body2">{o.pmtde ? o.pmtde.nombre : ''}</Typography>
                 <Box sx={{ mt: 1 }}>
                   <Tooltip title="Editar">
@@ -199,6 +201,14 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar organización' : 'Nueva organización'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            label="Código*"
+            value={current.codigo}
+            inputProps={{ maxLength: 10, style: { textTransform: 'uppercase' } }}
+            onChange={(e) =>
+              setCurrent({ ...current, codigo: e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '') })
+            }
+          />
           <TextField
             label="Nombre*"
             value={current.nombre}


### PR DESCRIPTION
## Summary
- add `codigo` fields to organizaciones, normativas and inputs with automatic generation for inputs
- document new code fields and update data model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a0ce08ac833194fa826f071fd99c