### PR TITLE
docs: document inputs-objectives traceability

### DIFF
--- a/docs/funcional/01 Modelo de datos.md
+++ b/docs/funcional/01 Modelo de datos.md
@@ -178,5 +178,13 @@ description: "Descripción de las entidades y campos de la aplicación"
 | codigo | VARCHAR(255) | SI |  |  |  |
 | descripcion | TEXT | SI |  |  |  |
 
+## inputs_objetivosE_trazabilidad
+| Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
+|-------|---------------|-------------|-------------------|------------|------------------------|
+| plan_id | INT | SI |  | planes_estrategicos.id | SI |
+| input_id | INT | SI |  | inputs.id | SI |
+| objetivoE_id | INT | SI |  | objetivos_estrategicos.id | SI |
+| nivel | INT | SI | 0 |  |  |
+
 
 

--- a/docs/funcional/use-cases/planes-estrategicos/00 Menu Planes Estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/00 Menu Planes Estrategicos.md
@@ -1,19 +1,20 @@
 ---
 title: "Casos de Uso - Menú Planes Estratégicos"
 domain: "Planes Estratégicos"
-version: "1.1"
+version: "1.2"
 date: "2025-08-21"
 author: "DGSIC"
 ---
 
 # Menú Planes Estratégicos
 
-El menú **Planes Estratégicos** organiza la gestión en cinco submenús visibles en el siguiente orden:
+El menú **Planes Estratégicos** organiza la gestión en seis submenús visibles en el siguiente orden:
 
 1. **Planes** – Administración de planes estratégicos.
 2. **Principios específicos** – Gestión de principios vinculados a los planes.
 3. **Objetivos estratégicos** – Definición de objetivos y sus evidencias.
-4. **DAFO planes estratégicos** – Matrices DAFO asociadas a cada plan.
-5. **DAFO programas guardarrail** – Registros DAFO vinculados a programas guardarrail.
+4. **Trazabilidad inputs vs objetivos** – Matriz de relación entre inputs y objetivos estratégicos.
+5. **DAFO planes estratégicos** – Matrices DAFO asociadas a cada plan.
+6. **DAFO programas guardarrail** – Registros DAFO vinculados a programas guardarrail.
 
 Cada submenú enlaza con los casos de uso descritos en los ficheros correspondientes.

--- a/docs/funcional/use-cases/planes-estrategicos/01 Planes estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/01 Planes estrategicos.md
@@ -1,8 +1,8 @@
 ---
 title: "Casos de Uso - Planes estratégicos"
 domain: "Planes estratégicos"
-version: "1.0"
-date: "2025-08-18"
+version: "1.1"
+date: "2025-08-21"
 author: "DGSIC"
 ---
 
@@ -10,7 +10,7 @@ author: "DGSIC"
 
 ## Contexto
 La aplicación permite gestionar Planes estratégicos vinculados a los PMTDE.
-En el menú "Planes estratégicos", el submenú "Planes" se muestra en primer lugar, seguido de "Principios específicos", "Objetivos estratégicos" y "DAFO Planes estratégicos".
+En el menú "Planes estratégicos", el submenú "Planes" se muestra en primer lugar, seguido de "Principios específicos", "Objetivos estratégicos", "Trazabilidad inputs vs objetivos" y "DAFO Planes estratégicos".
 
 ---
 

--- a/docs/funcional/use-cases/planes-estrategicos/02 Principios especificos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/02 Principios especificos.md
@@ -1,8 +1,8 @@
 ---
 title: "Casos de Uso - Principios específicos"
 domain: "Planes Estratégicos"
-version: "1.0"
-date: "2025-08-18"
+version: "1.1"
+date: "2025-08-21"
 author: "DGSIC"
 ---
 
@@ -10,7 +10,7 @@ author: "DGSIC"
 
 ## Contexto
 La aplicación permite gestionar principios específicos vinculados a los planes estratégicos.
-Dentro del menú "Planes estratégicos", el submenú "Principios específicos" se muestra en segundo lugar, precedido por "Planes" y seguido de "Objetivos estratégicos" y "DAFO Planes estratégicos".
+Dentro del menú "Planes estratégicos", el submenú "Principios específicos" se muestra en segundo lugar, precedido por "Planes" y seguido de "Objetivos estratégicos", "Trazabilidad inputs vs objetivos" y "DAFO Planes estratégicos".
 
 ---
 

--- a/docs/funcional/use-cases/planes-estrategicos/03 Objetivos Estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/03 Objetivos Estrategicos.md
@@ -1,15 +1,15 @@
 ---
 title: "Casos de Uso - Gestión de Objetivos Estrategicos"
 domain: "Planes Estratégicos"
-version: "1.0"
-date: "2025-08-18"
+version: "1.1"
+date: "2025-08-21"
 author: "DGSIC"
 ---
 
 # Casos de Uso: Gestión de Objetivos Estratégicos
 
 ## Contexto
-El submenú "Objetivos estratégicos" forma parte del menú "Planes estratégicos" y se ubica en tercer lugar, después de "Planes" y "Principios específicos" y antes de "DAFO Planes estratégicos".
+El submenú "Objetivos estratégicos" forma parte del menú "Planes estratégicos" y se ubica en tercer lugar, después de "Planes" y "Principios específicos" y antes de "Trazabilidad inputs vs objetivos" y "DAFO Planes estratégicos".
 Cada **objetivo estratégico** está vinculado obligatoriamente a un **plan estratégico** y podrá contener **evidencias** asociadas.
 
 ---

--- a/docs/funcional/use-cases/planes-estrategicos/04 Trazabilidad Inputs vs Objetivos Estratégicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/04 Trazabilidad Inputs vs Objetivos Estratégicos.md
@@ -1,0 +1,67 @@
+---
+title: "Casos de Uso - Trazabilidad Inputs vs Objetivos Estratégicos"
+domain: "Planes Estratégicos"
+version: "1.0"
+date: "2025-08-21"
+author: "DGSIC"
+---
+
+# Casos de Uso: Trazabilidad Inputs vs Objetivos Estratégicos
+
+## Contexto
+Se incorpora un submenú "Trazabilidad inputs vs objetivos" dentro de "Planes estratégicos" para gestionar la relación entre cada **input** y los **objetivos estratégicos** del plan mediante una pantalla de gestión especial con distintos niveles de trazabilidad.
+Todas las pantallas relacionadas muestran en la parte superior un título con el nombre de la entidad para facilitar la identificación.
+
+---
+
+## Caso de Uso 1: Visualizar Matriz de Trazabilidad
+**Actores principales:** Usuario.
+
+**Precondiciones:**
+- Existen inputs y objetivos estratégicos registrados en el plan seleccionado.
+
+**Flujo principal:**
+1. El usuario accede a "Planes estratégicos" → "Trazabilidad inputs vs objetivos".
+2. El sistema muestra una tabla de doble entrada en la que:
+   - Las columnas corresponden a los inputs.
+   - Las filas representan los objetivos estratégicos.
+   - El usuario puede elegir si visualizar únicamente los códigos o el formato "código - título" tanto en filas como en columnas.
+   - Al situar el cursor sobre un input u objetivo se muestra un tooltip cuya primera línea, en negrita, contiene el código y el título con el formato "código - nombre"; en líneas sucesivas se muestra su descripción.
+   - En cada celda se muestra el nivel de trazabilidad asociado entre input y objetivo:
+     - **0 – "Sin relación"**, representada por un guion **"-"**.
+     - **1 – "Baja"**, representada por **un círculo verde claro**.
+     - **2 – "Media"**, representada por **dos círculos verde medio**.
+     - **3 – "Alta"**, representada por **tres círculos verde oscuro**.
+     - **4 – "No aplica"**, mostrado como texto **"N/A"**.
+     Los círculos muestran un gradiente de verde cada vez más oscuro.
+
+**Postcondiciones:**
+- El usuario visualiza la matriz de trazabilidad con los valores actuales para cada combinación input–objetivo.
+
+---
+
+## Caso de Uso 2: Actualizar Nivel de Trazabilidad
+**Actores principales:** Usuario administrador o gestor autorizado.
+
+**Precondiciones:**
+- La matriz de trazabilidad está visible.
+
+**Flujo principal:**
+1. El usuario selecciona una celda correspondiente a un input y un objetivo.
+2. Se muestra un desplegable con los valores posibles:
+   - **0 – "Sin relación"**, representada por un guion **"-"**.
+   - **1 – "Baja"**, representada por **un círculo verde claro**.
+   - **2 – "Media"**, representada por **dos círculos verde medio**.
+   - **3 – "Alta"**, representada por **tres círculos verde oscuro**.
+   - **4 – "No aplica"**, mostrado como texto **"N/A"**.
+3. El usuario elige un valor. El control queda desactivado hasta completar la operación; si dura más de un segundo aparece el banner "Procesando... X seg".
+4. El sistema guarda automáticamente el nivel seleccionado, refresca la matriz y muestra un banner superior confirmando la actualización.
+
+**Postcondiciones:**
+- La relación entre input y objetivo queda registrada con el nivel elegido.
+
+**Reglas de negocio:**
+- Cada combinación input–objetivo tiene un único nivel de trazabilidad.
+- El nivel por defecto es **0 (Sin relación)**.
+
+---

--- a/docs/funcional/use-cases/planes-estrategicos/05 DAFO Planes Estratégicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/05 DAFO Planes Estratégicos.md
@@ -1,7 +1,7 @@
 ---
 title: "Casos de Uso - Matrices DAFO Planes Estratégicos"
 domain: "Planes estratégicos"
-version: "1.0"
+version: "1.1"
 date: "2025-08-21"
 author: "DGSIC"
 ---
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: Matrices DAFO de Planes Estratégicos
 
 ## Contexto
-La aplicación permite gestionar registros **DAFO** asociados a un **plan estratégico**. Cada registro se vincula a un plan y se clasifica por tipo. Todas las pantallas relacionadas muestran en la parte superior un título con el nombre de la entidad para facilitar la identificación. Dentro del menú "Planes estratégicos", el submenú "DAFO Planes estratégicos" se muestra en último lugar.
+La aplicación permite gestionar registros **DAFO** asociados a un **plan estratégico**. Cada registro se vincula a un plan y se clasifica por tipo. Todas las pantallas relacionadas muestran en la parte superior un título con el nombre de la entidad para facilitar la identificación. Dentro del menú "Planes estratégicos", el submenú "DAFO Planes estratégicos" se muestra en quinto lugar, seguido de "DAFO programas guardarrail".
 
 ---
 


### PR DESCRIPTION
## Summary
- document new traceability matrix linking inputs and strategic objectives
- update strategic plan menu docs to include traceability screen
- extend data model with `inputs_objetivosE_trazabilidad` entity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7a56242288331b8c1cae35e9b2842