### PR TITLE
docs: añadir gestión de preferencias de usuario

### DIFF
--- a/docs/funcional/01 Modelo de datos.md
+++ b/docs/funcional/01 Modelo de datos.md
@@ -164,6 +164,16 @@ description: "Descripción de las entidades y campos de la aplicación"
 | tabla | VARCHAR(255) | SI |  |  |  |
 | columnas | TEXT | SI |  |  |  |
 
+## userPreferences
+| Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
+|-------|---------------|-------------|-------------------|------------|------------------------|
+| id | INT AUTO_INCREMENT | SI |  |  |  |
+| usuario_id | INT | SI |  | usuarios.id | SI |
+| clave | VARCHAR(255) | SI |  |  |  |
+| valor | VARCHAR(255) | SI |  |  |  |
+
+La preferencia inicial `densidad_de_contenido` admite los valores `Compacto`, `Normal` y `Extendido` y define el espaciado de la interfaz.
+
 ## objetivos_estrategicos
 | Campo | Tipo de datos | Obligatorio | Valor por defecto | Referencia | Eliminación en cascada |
 |-------|---------------|-------------|-------------------|------------|------------------------|

--- a/docs/guardarails/AGENTS_03 UX_UI.MD
+++ b/docs/guardarails/AGENTS_03 UX_UI.MD
@@ -15,6 +15,15 @@ Todas las pantallas y funcionalidades de la aplicación deben cumplir las siguie
 - Todas las interfaces deberán ser responsive, de forma que se adapten correctamente a la visualización en cualquier tipo de terminal: pc, tablet, móvil, etc.
 - Todos los botones de acciones sobre listados de elementos (tablas, cards, ec), se mostrarán con un icono y no con texto en el botón.
 
+## Gestión de preferencias de usuario
+- El menú de perfil incluirá una opción para configurar las preferencias personales.
+- Las preferencias se almacenarán en la tabla `userPreferences` asociadas a cada usuario.
+- La primera preferencia disponible es **densidad de contenido** con valores `Compacto`, `Normal` y `Extendido`.
+- `Extendido` mantiene el espaciado amplio actual de tablas, menú lateral y demás componentes.
+- `Compacto` reducirá márgenes y separaciones al mínimo permitiendo mostrar más información en pantalla.
+- `Normal` aplicará márgenes intermedios entre los valores de `Extendido` y `Compacto`.
+- Al modificar la densidad de contenido, la aplicación se volverá a renderizar para aplicar el nuevo espaciado.
+
 ## Formato Markdown en descripciones amplias
 - Todos los campos de descripción amplia del sistema permitirán formato **markdown**.
 - Los componentes de texto largo mostrarán las marcas **markdown** durante la edición, pero en modo solo lectura se renderizará el formato (por ejemplo, en celdas de tablas no editables).


### PR DESCRIPTION
## Summary
- documentar opción de perfil para gestionar preferencias del usuario
- describir la nueva tabla `userPreferences` con la preferencia `densidad_de_contenido`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7a71369908331a5a8df1712ab3f3d