### PR TITLE
Add traceability matrix between inputs and strategic objectives

### DIFF
--- a/backend/changelog.json
+++ b/backend/changelog.json
@@ -43,5 +43,10 @@
     "tipo": "M",
     "fecha": "2025-08-21",
     "descripcion": "Se realizan modificaciones en el código para la trazabilidad de los guardarrailes."
+  },
+  {
+    "tipo": "M",
+    "fecha": "2025-08-21",
+    "descripcion": "Se añade la matriz de trazabilidad entre inputs y objetivos estratégicos."
   }
 ]

--- a/backend/routes/trazabilidadInputsObjetivos.js
+++ b/backend/routes/trazabilidadInputsObjetivos.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const { getDb } = require('../db');
+
+const router = express.Router();
+
+router.get('/:planId', async (req, res) => {
+  const pool = getDb();
+  const planId = parseInt(req.params.planId, 10) || 1;
+  const [inputs] = await pool.query(
+    'SELECT id, codigo, titulo, descripcion FROM inputs'
+  );
+  const [objetivos] = await pool.query(
+    'SELECT id, codigo, titulo, descripcion FROM objetivos_estrategicos WHERE plan_id=?',
+    [planId]
+  );
+  const [relaciones] = await pool.query(
+    'SELECT input_id, objetivoE_id, nivel FROM inputs_objetivosE_trazabilidad WHERE plan_id=?',
+    [planId]
+  );
+  res.json({ inputs, objetivos, relaciones });
+});
+
+router.post('/', async (req, res) => {
+  const pool = getDb();
+  const planId = req.body.planId || 1;
+  const inputId = req.body.inputId || 1;
+  const objetivoEId = req.body.objetivoEId || 1;
+  const nivel = req.body.nivel != null ? req.body.nivel : 0;
+  await pool.query(
+    `INSERT INTO inputs_objetivosE_trazabilidad (plan_id, input_id, objetivoE_id, nivel)
+     VALUES (?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE nivel=VALUES(nivel)`,
+    [planId, inputId, objetivoEId, nivel]
+  );
+  res.json({ planId, inputId, objetivoEId, nivel });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -21,6 +21,7 @@ const objetivosEstrategicosEvidenciasRouter = require('./routes/objetivosEstrate
 const objetivosGuardarrailRouter = require('./routes/objetivosGuardarrail');
 const objetivosGuardarrailEvidenciasRouter = require('./routes/objetivosGuardarrailEvidencias');
 const trazabilidadRouter = require('./routes/trazabilidadPrincipiosGRObjetivosGR');
+const trazabilidadInputsObjetivosRouter = require('./routes/trazabilidadInputsObjetivos');
 const dafoProgramasGuardarrailRouter = require('./routes/dafoProgramasGuardarrail');
 
 const preferenciasRouter = require('./routes/preferencias');
@@ -66,6 +67,7 @@ app.use('/api/objetivosEstrategicosEvidencias', objetivosEstrategicosEvidenciasR
 app.use('/api/objetivosGuardarrail', objetivosGuardarrailRouter);
 app.use('/api/objetivosGuardarrailEvidencias', objetivosGuardarrailEvidenciasRouter);
 app.use('/api/trazabilidad', trazabilidadRouter);
+app.use('/api/trazabilidadInputsObjetivos', trazabilidadInputsObjetivosRouter);
 app.use('/api/dafoProgramasGuardarrail', dafoProgramasGuardarrailRouter);
 
 app.use('/api/principiosEspecificos', principiosRouter);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,6 +42,7 @@
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailEvidenciasApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/TrazabilidadPrincipioGRObjetivoGRApi.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/TrazabilidadInputsObjetivosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PrincipiosEspecificosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ParametrosApi.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ChangelogApi.js"></script>
@@ -69,6 +70,7 @@
   <script type="text/babel" data-presets="env,react" src="js/ObjetivosGuardarrailManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/PrincipiosEspecificosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/TrazabilidadPrincipioGRObjetivoGRManager.js"></script>
+  <script type="text/babel" data-presets="env,react" src="js/TrazabilidadInputsObjetivosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ParametrosManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ImportExportManager.js"></script>
   <script type="text/babel" data-presets="env,react" src="js/ChangelogManager.js"></script>

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -261,6 +261,12 @@ function App() {
                 </ListItemIcon>
                 <ListItemText primary="Objetivos estratégicos" />
               </ListItemButton>
+              <ListItemButton sx={{ pl: 4 }} onClick={() => go('trazabilidadInputsObjetivos')}>
+                <ListItemIcon>
+                  <span className="material-symbols-outlined">grid_on</span>
+                </ListItemIcon>
+                <ListItemText primary="Trazabilidad inputs vs objetivos" />
+              </ListItemButton>
               <ListItemButton sx={{ pl: 4 }} onClick={() => go('dafoPlanesEstrategicos')}>
                 <ListItemIcon>
                   <span className="material-symbols-outlined">category</span>
@@ -321,6 +327,9 @@ function App() {
           <PlanesEstrategicosManager usuarios={usuarios} pmtde={pmtde} />
         )}
         {view === 'objetivosEstrategicos' && <ObjetivosEstrategicosManager />}
+        {view === 'trazabilidadInputsObjetivos' && (
+          <TrazabilidadInputsObjetivosManager />
+        )}
         {view === 'principiosEspecificos' && <PrincipiosEspecificosManager />}
         {view === 'dafoPlanesEstrategicos' && <DafoPlanesEstrategicosManager />}
         {view === 'dafoProgramasGuardarrail' && <DafoProgramasGuardarrailManager />}

--- a/frontend/js/TrazabilidadInputsObjetivosApi.js
+++ b/frontend/js/TrazabilidadInputsObjetivosApi.js
@@ -1,0 +1,14 @@
+const trazabilidadInputsObjetivosApi = {
+  get: async (planId) => {
+    const res = await fetch(`/api/trazabilidadInputsObjetivos/${planId}`);
+    return res.json();
+  },
+  save: async ({ planId, inputId, objetivoEId, nivel }) => {
+    const res = await fetch('/api/trazabilidadInputsObjetivos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ planId, inputId, objetivoEId, nivel }),
+    });
+    return res.json();
+  },
+};

--- a/frontend/js/TrazabilidadInputsObjetivosManager.js
+++ b/frontend/js/TrazabilidadInputsObjetivosManager.js
@@ -1,0 +1,240 @@
+function TrazabilidadInputsObjetivosManager() {
+  const [plan, setPlan] = React.useState(null);
+  const [planes, setPlanes] = React.useState([]);
+  const [inputs, setInputs] = React.useState([]);
+  const [objetivos, setObjetivos] = React.useState([]);
+  const [relaciones, setRelaciones] = React.useState({});
+  const [editing, setEditing] = React.useState(null);
+  const [snack, setSnack] = React.useState(false);
+  const [displayMode, setDisplayMode] = React.useState('code');
+  const { busy, seconds, perform } = useProcessing();
+
+  React.useEffect(() => {
+    planesEstrategicosApi.list().then(setPlanes);
+  }, []);
+
+  const load = async (planId) => {
+    const data = await trazabilidadInputsObjetivosApi.get(planId);
+    setInputs(data.inputs);
+    setObjetivos(data.objetivos);
+    const map = {};
+    (data.relaciones || []).forEach((r) => {
+      map[`${r.input_id}-${r.objetivoE_id}`] = r.nivel;
+    });
+    setRelaciones(map);
+  };
+
+  const formatLabel = (item) =>
+    displayMode === 'codeTitle' ? `${item.codigo} - ${item.titulo}` : item.codigo;
+
+  const tooltipContent = (codigo, titulo, descripcion) => (
+    <React.Fragment>
+      <Typography fontWeight="bold">{`${codigo} - ${titulo}`}</Typography>
+      {descripcion && (
+        <Typography sx={{ whiteSpace: 'pre-line' }}>{descripcion}</Typography>
+      )}
+    </React.Fragment>
+  );
+
+  const handlePlanChange = (val) => {
+    setPlan(val);
+    if (val) load(val.id);
+  };
+
+  const handleCellClick = (objId, inputId) => {
+    if (busy) return;
+    const key = `${inputId}-${objId}`;
+    const value = relaciones[key] != null ? relaciones[key] : 0;
+    setEditing({ objId, inputId, value });
+  };
+
+  const handleLevelChange = async (value) => {
+    const { objId, inputId } = editing;
+    await perform(async () => {
+      await trazabilidadInputsObjetivosApi.save({
+        planId: plan.id,
+        inputId,
+        objetivoEId: objId,
+        nivel: value,
+      });
+      await load(plan.id);
+      setSnack(true);
+    });
+    setEditing(null);
+  };
+
+  const renderCell = (objId, inputId) => {
+    const key = `${inputId}-${objId}`;
+    const nivel = relaciones[key];
+    if (editing && editing.objId === objId && editing.inputId === inputId) {
+      return (
+        <Select
+          value={editing.value}
+          open
+          onChange={(e) => handleLevelChange(parseInt(e.target.value, 10))}
+          onClose={() => setEditing(null)}
+          disabled={busy}
+          autoWidth
+        >
+          <MenuItem value={0}>Sin relación</MenuItem>
+          <MenuItem value={1}>Baja</MenuItem>
+          <MenuItem value={2}>Media</MenuItem>
+          <MenuItem value={3}>Alta</MenuItem>
+          <MenuItem value={4}>N/A</MenuItem>
+        </Select>
+      );
+    }
+    if (nivel == null || nivel === 0) return '-';
+    if (nivel === 4) return 'N/A';
+    const colors = ['#a5d6a7', '#66bb6a', '#2e7d32'];
+    return (
+      <span>
+        {Array.from({ length: nivel }).map((_, i) => (
+          <span
+            key={i}
+            className="material-symbols-outlined"
+            style={{ color: colors[i] }}
+          >
+            fiber_manual_record
+          </span>
+        ))}
+      </span>
+    );
+  };
+
+  const exportCSV = () => {
+    if (!plan) return;
+    const headers = ['Objetivo \\ Input', ...inputs.map((i) => i.codigo)];
+    const rows = objetivos.map((o) => {
+      const row = [o.codigo];
+      inputs.forEach((i) => {
+        const key = `${i.id}-${o.id}`;
+        const nivel = relaciones[key];
+        if (nivel == null || nivel === 0) row.push('Sin relación');
+        else if (nivel === 1) row.push('Baja');
+        else if (nivel === 2) row.push('Media');
+        else if (nivel === 3) row.push('Alta');
+        else row.push('N/A');
+      });
+      return row;
+    });
+    exportToCSV(headers, rows, 'TrazabilidadInputsObjetivos');
+  };
+
+  const exportPDF = () => {
+    if (!plan) return;
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text('Trazabilidad inputs vs objetivos estratégicos', 10, 10);
+    let y = 20;
+    const header = ['Objetivo', ...inputs.map((i) => i.codigo)].join(' | ');
+    doc.text(header, 10, y);
+    y += 10;
+    objetivos.forEach((o) => {
+      const vals = [o.codigo];
+      inputs.forEach((i) => {
+        const key = `${i.id}-${o.id}`;
+        const nivel = relaciones[key];
+        if (nivel == null || nivel === 0) vals.push('Sin relación');
+        else if (nivel === 1) vals.push('Baja');
+        else if (nivel === 2) vals.push('Media');
+        else if (nivel === 3) vals.push('Alta');
+        else vals.push('N/A');
+      });
+      doc.text(vals.join(' | '), 10, y);
+      y += 10;
+      if (y > 280) {
+        doc.addPage();
+        y = 10;
+      }
+    });
+    doc.save(`${formatDate()} TrazabilidadInputsObjetivos.pdf`);
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Trazabilidad inputs vs objetivos estratégicos
+      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Autocomplete
+          options={planes}
+          getOptionLabel={(p) => p.nombre}
+          value={plan}
+          onChange={(e, val) => handlePlanChange(val)}
+          renderInput={(params) => <TextField {...params} label="Plan estratégico*" />}
+          sx={{ minWidth: 300 }}
+        />
+        <FormControl size="small" sx={{ minWidth: 180 }}>
+          <InputLabel id="display-mode-label">Formato</InputLabel>
+          <Select
+            labelId="display-mode-label"
+            value={displayMode}
+            label="Formato"
+            onChange={(e) => setDisplayMode(e.target.value)}
+          >
+            <MenuItem value="code">Solo códigos</MenuItem>
+            <MenuItem value="codeTitle">Código y título</MenuItem>
+          </Select>
+        </FormControl>
+        <Tooltip title="Exportar CSV">
+          <span>
+            <IconButton onClick={exportCSV} disabled={!plan || busy}>
+              <span className="material-symbols-outlined">download</span>
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title="Exportar PDF">
+          <span>
+            <IconButton onClick={exportPDF} disabled={!plan || busy}>
+              <span className="material-symbols-outlined">picture_as_pdf</span>
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Box>
+      {plan && (
+        <Table>
+          <TableHead sx={tableHeadSx}>
+            <TableRow>
+              <TableCell>Objetivo \\ Input</TableCell>
+              {inputs.map((i) => (
+                <TableCell key={i.id}>
+                  <Tooltip title={tooltipContent(i.codigo, i.titulo, i.descripcion)}>
+                    <span>{formatLabel(i)}</span>
+                  </Tooltip>
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {objetivos.map((o) => (
+              <TableRow key={o.id}>
+                <TableCell>
+                  <Tooltip title={tooltipContent(o.codigo, o.titulo, o.descripcion)}>
+                    <span>{formatLabel(o)}</span>
+                  </Tooltip>
+                </TableCell>
+                {inputs.map((i) => (
+                  <TableCell
+                    key={i.id}
+                    onClick={() => handleCellClick(o.id, i.id)}
+                    sx={{ cursor: 'pointer' }}
+                  >
+                    {renderCell(o.id, i.id)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+      <ProcessingBanner seconds={seconds} />
+      <Snackbar
+        open={snack}
+        autoHideDuration={3000}
+        onClose={() => setSnack(false)}
+        message="Nivel actualizado"
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add backend API for input-to-objective traceability and expose new route
- integrate frontend manager to edit and export the traceability matrix
- link traceability view into strategic plans menu and update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7a78775f08331ba5a7827d026bb52