### PR TITLE
Crear tabla de trazabilidad inputs-objetivos estratégicos

### DIFF
--- a/backend/changelog.json
+++ b/backend/changelog.json
@@ -48,5 +48,10 @@
     "tipo": "M",
     "fecha": "2025-08-21",
     "descripcion": "Se añade la matriz de trazabilidad entre inputs y objetivos estratégicos."
+  },
+  {
+    "tipo": "I",
+    "fecha": "2025-08-22",
+    "descripcion": "Se crea la tabla inputs_objetivosE_trazabilidad para evitar error 500 al cargar su trazabilidad."
   }
 ]

--- a/backend/db.js
+++ b/backend/db.js
@@ -364,6 +364,19 @@ async function initDb() {
   );
 
   await pool.query(
+    `CREATE TABLE IF NOT EXISTS inputs_objetivosE_trazabilidad (
+      plan_id INT NOT NULL,
+      input_id INT NOT NULL,
+      objetivoE_id INT NOT NULL,
+      nivel INT NOT NULL DEFAULT 0,
+      PRIMARY KEY (plan_id, input_id, objetivoE_id),
+      FOREIGN KEY (plan_id) REFERENCES planes_estrategicos(id) ON DELETE CASCADE,
+      FOREIGN KEY (input_id) REFERENCES inputs(id) ON DELETE CASCADE,
+      FOREIGN KEY (objetivoE_id) REFERENCES objetivos_estrategicos(id) ON DELETE CASCADE
+    )`
+  );
+
+  await pool.query(
     `CREATE TABLE IF NOT EXISTS dafo_pe (
       id INT AUTO_INCREMENT PRIMARY KEY,
       plan_id INT NOT NULL,


### PR DESCRIPTION
## Summary
- crea la tabla `inputs_objetivosE_trazabilidad` en la inicialización de BD para evitar errores 500
- registra la corrección en el `changelog`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7b75935b48331abaef22f0f849e26