### PR TITLE
Enhance density preferences for more compact layouts

### DIFF
--- a/docs/guardarails/AGENTS_03 UX_UI.MD
+++ b/docs/guardarails/AGENTS_03 UX_UI.MD
@@ -19,10 +19,11 @@ Todas las pantallas y funcionalidades de la aplicación deben cumplir las siguie
 - El menú de perfil incluirá una opción para configurar las preferencias personales.
 - Las preferencias se almacenarán en la tabla `userPreferences` asociadas a cada usuario.
 - La primera preferencia disponible es **densidad de contenido** con valores `Compacto`, `Normal` y `Extendido`.
-- `Extendido` mantiene el espaciado amplio tipo de material design en tablas, menú lateral y demás componentes.
-- `Compacto` reducirá márgenes y separaciones al mínimo permitiendo mostrar más información en pantalla.
-- `Normal` aplicará márgenes intermedios entre los valores de `Extendido` y `Compacto`.
-- Al modificar la densidad de contenido, la aplicación se volverá a renderizar para aplicar el nuevo espaciado.
+- La densidad ajustará el **padding**, el **tamaño de fuente** y la **altura mínima** de tablas, listas, barras de herramientas y botones.
+- `Extendido` aplica márgenes y alturas generosos pensados para una lectura cómoda.
+- `Compacto` minimiza márgenes, tamaño de fuente y altura de componentes para mostrar la máxima información posible.
+- `Normal` se sitúa en un punto medio entre los valores de `Extendido` y `Compacto`.
+- Al modificar la densidad de contenido, la aplicación se volverá a renderizar para aplicar el nuevo formato.
 
 ## Formato Markdown en descripciones amplias
 - Todos los campos de descripción amplia del sistema permitirán formato **markdown**.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,14 +12,33 @@
       background-color: #f5f5f5;
       font-weight: 600;
     }
-    body { --density-padding: 16px; }
-    body.density-compacto { --density-padding: 4px; }
-    body.density-normal { --density-padding: 8px; }
-    body.density-extendido { --density-padding: 16px; }
+    body {
+      --density-padding: 24px;
+      --density-font-size: 1rem;
+      --density-min-height: 56px;
+    }
+    body.density-compacto {
+      --density-padding: 2px;
+      --density-font-size: 0.75rem;
+      --density-min-height: 24px;
+    }
+    body.density-normal {
+      --density-padding: 8px;
+      --density-font-size: 0.875rem;
+      --density-min-height: 36px;
+    }
+    body.density-extendido {
+      --density-padding: 24px;
+      --density-font-size: 1rem;
+      --density-min-height: 56px;
+    }
     .MuiTableCell-root,
     .MuiListItem-root,
-    .MuiToolbar-root {
+    .MuiToolbar-root,
+    .MuiButton-root {
       padding: var(--density-padding) !important;
+      font-size: var(--density-font-size) !important;
+      min-height: var(--density-min-height) !important;
     }
   </style>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>


### PR DESCRIPTION
## Summary
- Increase contrast between density options by adjusting padding, font-size and minimum component heights
- Document updated density behavior in UX/UI guardrails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7b7cf4b84833182a1451e497442b4