### PR TITLE
docs: clarify column preferences for table and card views

### DIFF
--- a/docs/guardarails/AGENTS_03 UX_UI.MD
+++ b/docs/guardarails/AGENTS_03 UX_UI.MD
@@ -18,6 +18,7 @@ Todas las pantallas y funcionalidades de la aplicación deben cumplir las siguie
 ## Gestión de preferencias de usuario
 - El menú de perfil incluirá una opción para configurar las preferencias personales.
 - Las preferencias se almacenarán en la tabla `userPreferences` asociadas a cada usuario.
+- La tabla `userPreferences` incluirá un campo `viewType` para distinguir si una configuración de columnas pertenece a la vista `table` o `cards`.
 - La primera preferencia disponible es **densidad de contenido** con valores `Compacto`, `Normal` y `Extendido`.
 - `Extendido` mantiene el espaciado amplio tipo de material design en tablas, menú lateral y demás componentes.
 - `Compacto` reducirá márgenes y separaciones al mínimo permitiendo mostrar más información en pantalla.

--- a/docs/guardarails/AGENTS_04 LISTADOS.MD
+++ b/docs/guardarails/AGENTS_04 LISTADOS.MD
@@ -1,7 +1,13 @@
+---
+title: "Listados de elementos"
+---
+
 # LISTADOS DE ELEMENTOS
 
 Revisa todas las pantallas de la aplicación para asegurarte de que se aplica las siguientes funcionalidades en los listados de elementos de todas las entidades:	
 - Cuando visualicemos cualquier listado de elementos de cualquier entidad, maestra o no, deberemos poder visualizar los resultados en formato tabla y en formato cards. Esto incluye también a los listados de elementos que se muestren en formularios normales, en formularios popup en general en cualquier sitio.
 - En formato tabla deberá permitir ordenar por cualquiera de las columnas mostradas.
+- Las columnas visibles se podrán configurar tanto para la vista tabla como para la vista cards.
+- Estas configuraciones se guardarán en la tabla `userPreferences` diferenciando el tipo de vista (`table` o `cards`).
 
 

--- a/docs/guardarails/AGENTS_06 TABLAS.MD
+++ b/docs/guardarails/AGENTS_06 TABLAS.MD
@@ -1,3 +1,7 @@
+---
+title: "Formato de tablas"
+---
+
 # FORMATO DE TABLAS
 
 Revisa todas las tablas para asegurarte de que el formato de tablas para todas ellas cumple que:
@@ -5,13 +9,14 @@ Revisa todas las tablas para asegurarte de que el formato de tablas para todas e
 - Aplica a las cabeceras de estas tablas un formato diferenciado para que se vea claramente que son la cabecera de las mismas  pero que no sea demasiado llamativo. 
 - Todas las tablas de las listas de elementos tienen que tener la opción de ordenar ascendente y descendentemente por cualquiera de los campos por valores.
 
-# PREFERENCIAS DE USUARIO EN LAS TABLAS
+# PREFERENCIAS DE USUARIO EN LAS TABLAS Y CARDS
 
-- Quiero que todas las visualizaciones de tipo tabla de la aplicación, tengan un icono con un botón de acción de "selección de columnas" que permita que el usuario seleccione las columnas de la tabla que quiere ver y el orden en el que quiere verlas. La columna con los botones de acción siempre será la última y no será configurable su posición. Tendrá una opción guardar que guardará en base de datos estas preferecias.
-- Deberá existir en el sistema una entidad "preferencias de usuario" que persista, asociado al usuario logado en la aplicación, sus preferencias en cada una de las tablas del sistema: columnas visibles y orden en el que se muestran. Si no existe token de sesion de un usuario logado, se guardarán las preferencias asociados al usuario "anonimo".
-- Esta visualización elegida por el usuario para cada una de las tablas será persistida en una tabla de personalizaciones, donde guardaremos el usuario al que se vinculan (usuario anonimo en caso de que no haya token de sesión con un usuario identificado), el nombre de la interfaz concreta, y la selección de campos y orden de los mismos que el usuario ha seleccionado. Identificaremos al usuario en esta tabla de preferencias de usuario mediante su id de usuario cuando se logue.
-- La próxima vez que el usuario entre en esta interfaz, se recuperará esta configuración para mostrar la tabla con las columnas y ordenación de las mismas que este había personalizado para si. 
-- Igualmente cuando volvamos a pulsar en el botón de "selección de columnas", se cargará la parametrización que estaba persistirda
-- Implementa para que la ordenación de las columnas seleccionadas se pueda realizar mediante drag & drop en el popup de selección de columnas
+- Quiero que todas las visualizaciones de tipo tabla y cards de la aplicación tengan un icono con un botón de acción de "selección de columnas" que permita que el usuario seleccione las columnas o campos que quiere ver y el orden en el que quiere verlos. La columna con los botones de acción siempre será la última y no será configurable su posición en la vista de tabla. Tendrá una opción guardar que guardará en base de datos estas preferencias.
+- Deberá existir en el sistema una entidad "preferencias de usuario" que persista, asociado al usuario logado en la aplicación, sus preferencias en cada una de las vistas del sistema (tabla o cards): columnas visibles y orden en el que se muestran. Si no existe token de sesión de un usuario logado, se guardarán las preferencias asociados al usuario "anonimo".
+- La tabla de preferencias incluirá un campo `viewType` para diferenciar si la configuración corresponde a la vista `table` o `cards`.
+- Esta visualización elegida por el usuario para cada una de las vistas será persistida en una tabla de personalizaciones donde guardaremos el usuario al que se vinculan (usuario anonimo en caso de que no haya token de sesión con un usuario identificado), el nombre de la interfaz concreta, el tipo de vista (`table` o `cards`) y la selección de campos y orden de los mismos que el usuario ha seleccionado. Identificaremos al usuario en esta tabla de preferencias de usuario mediante su id de usuario cuando se logue.
+- La próxima vez que el usuario entre en esta interfaz, se recuperará esta configuración para mostrar la vista seleccionada (tabla o cards) con las columnas y ordenación de las mismas que este había personalizado para si.
+- Igualmente cuando volvamos a pulsar en el botón de "selección de columnas", se cargará la parametrización que estaba persistida para la vista actual.
+- Implementa para que la ordenación de las columnas o campos seleccionados se pueda realizar mediante drag & drop en el popup de selección de columnas
 - Traduce los nombres de columnas para que aparezca su label en español tal como aparecen en las cabeceras de las columnas.
 - En el selector de columnas, si haces movimientos drag & drop, este cambio de orden se debe refrescar en el popup de selección y ordenacion de columnas para que se visualice los cambios que se están haciendo.


### PR DESCRIPTION
## Summary
- document column selection capability for both table and card list views
- describe view-specific column preferences with new `viewType` field
- note that userPreferences stores table or card settings separately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7b86f2fbc83319d7ba3a62b2b175d