### PR TITLE
Ajusta densidad en menú lateral

### DIFF
--- a/docs/guardarails/AGENTS_03 UX_UI.MD
+++ b/docs/guardarails/AGENTS_03 UX_UI.MD
@@ -20,7 +20,7 @@ Todas las pantallas y funcionalidades de la aplicación deben cumplir las siguie
 - Las preferencias se almacenarán en la tabla `userPreferences` asociadas a cada usuario.
 - La tabla `userPreferences` incluirá un campo `viewType` para distinguir si una configuración de columnas pertenece a la vista `table` o `cards`.
 - La primera preferencia disponible es **densidad de contenido** con valores `Compacto`, `Normal` y `Extendido`.
-- La densidad ajustará el **padding**, el **tamaño de fuente** y la **altura mínima** de tablas, listas, barras de herramientas y botones.
+- La densidad ajustará el **padding**, el **tamaño de fuente** y la **altura mínima** de tablas, listas, barras de herramientas, botones y el menú lateral.
 - `Extendido` aplica márgenes y alturas generosos pensados para una lectura cómoda.
 - `Compacto` minimiza márgenes, tamaño de fuente y altura de componentes para mostrar la máxima información posible.
 - `Normal` se sitúa en un punto medio entre los valores de `Extendido` y `Compacto`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,11 +34,16 @@
     }
     .MuiTableCell-root,
     .MuiListItem-root,
+    .MuiListItemButton-root,
     .MuiToolbar-root,
     .MuiButton-root {
       padding: var(--density-padding) !important;
       font-size: var(--density-font-size) !important;
       min-height: var(--density-min-height) !important;
+    }
+
+    .MuiListItemIcon-root {
+      min-width: var(--density-min-height) !important;
     }
   </style>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>


### PR DESCRIPTION
## Summary
- Aplica la preferencia de densidad al menú lateral ajustando padding, tamaño de fuente y altura de sus elementos
- Documenta que la densidad afecta al menú lateral en las directrices de UX/UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7bb12cc4c833190811b3c9888b0ee