### PR TITLE
docs: documentar selección de PMTDE activo y filtrado global

### DIFF
--- a/docs/funcional/PMTDE/01 Gestión PMTDE.md
+++ b/docs/funcional/PMTDE/01 Gestión PMTDE.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: PMTDE
 
 ## Contexto
-La aplicación permite gestionar los registros del Programa Marco de Transformación Digital Efectiva.
+La aplicación permite gestionar los registros del Programa Marco de Transformación Digital Efectiva. Esta pantalla no está sujeta al filtro de PMTDE activo y siempre muestra todos los registros.
 Todas las pantallas relacionadas muestran en la parte superior un título con el nombre de la entidad.
 
 ---
@@ -64,7 +64,7 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 
 **Flujo principal:**
 1. El usuario abre el menú "PMTDE" y selecciona el submenú "PMTDE".
-2. El sistema muestra para cada PMTDE:
+2. El sistema muestra todos los PMTDE sin aplicar el filtro del PMTDE activo:
    - Nombre.
    - Descripción.
    - Propietario.

--- a/docs/funcional/PMTDE/02 Organizaciones.md
+++ b/docs/funcional/PMTDE/02 Organizaciones.md
@@ -61,13 +61,17 @@ Permite mantener la maestra de organizaciones asociadas a un PMTDE. Todos los ca
 ## Caso de Uso 4: Listar Organizaciones
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el submenú "Organizaciones".
-2. El sistema muestra para cada organización:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada organización:
    - Código.
    - Nombre.
    - PMTDE asociado.
-3. El usuario puede:
+4. El usuario puede:
    - Cambiar entre vista tabla o cards.
    - Ordenar por cualquier columna.
    - Abrir la sección de filtros para buscar texto, filtrar por PMTDE y reiniciar filtros.

--- a/docs/funcional/PMTDE/03 Normativa.md
+++ b/docs/funcional/PMTDE/03 Normativa.md
@@ -64,15 +64,19 @@ Gestiona la normativa emitida por las organizaciones dentro de un PMTDE. Los cam
 ## Caso de Uso 4: Listar Normativa
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el submenú "Normativa".
-2. El sistema muestra para cada normativa:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada normativa:
    - Código.
    - Nombre.
    - Tipo.
    - Organización emisora.
    - URL.
-3. El usuario puede:
+4. El usuario puede:
    - Cambiar entre vista tabla o cards.
    - Ordenar por cualquier columna.
    - Abrir la sección de filtros para buscar texto, filtrar por organización y tipo de normativa, y reiniciar filtros.

--- a/docs/funcional/PMTDE/04 Inputs.md
+++ b/docs/funcional/PMTDE/04 Inputs.md
@@ -63,14 +63,18 @@ Los inputs son las cuestiones que deben ejecutarse por exigencia de una normativ
 ## Caso de Uso 4: Listar Inputs
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el submenú "Inputs".
-2. El sistema muestra para cada input:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada input:
    - Código.
    - Título.
    - Normativa asociada (con el nombre de la organización entre paréntesis).
    - Descripción.
-3. El usuario puede:
+4. El usuario puede:
    - Cambiar entre vista tabla o cards.
    - Ordenar por cualquier columna.
    - Seleccionar las columnas visibles (Código, Título, Normativa, Descripción).

--- a/docs/funcional/use-cases/planes-estrategicos/01 Planes estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/01 Planes estrategicos.md
@@ -84,14 +84,18 @@ En el menú "Planes estratégicos", el submenú "Planes" se muestra en primer lu
 ## Caso de Uso 4: Listar Planes estratégicos
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el menú "Planes estratégicos" y selecciona el submenú "Planes".
-2. El sistema muestra para cada Plan estratégico:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada Plan estratégico:
    - PMTDE asociado.
    - Código.
    - Nombre y descripción.
    - Responsable y grupo de expertos.
-3. El usuario puede:
+4. El usuario puede:
    - Cambiar entre vista tabla o cards.
    - Ordenar por cualquier columna.
    - Abrir la sección de filtros para buscar texto, filtrar por PMTDE, responsable o expertos y reiniciar filtros.

--- a/docs/funcional/use-cases/planes-estrategicos/02 Principios especificos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/02 Principios especificos.md
@@ -77,13 +77,17 @@ Dentro del menú "Planes estratégicos", el submenú "Principios específicos" s
 ## Caso de Uso 4: Listar Principios Específicos
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el submenú "Principios específicos".
-2. El sistema muestra para cada principio:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada principio:
    - Código.
    - Plan estratégico.
    - Título y descripción.
-3. El usuario puede:
+4. El usuario puede:
    - Alternar entre vista tabla y cards.
    - Ordenar por cualquier columna.
    - Mostrar/ocultar filtros para búsqueda textual y por plan, con opción de reset.

--- a/docs/funcional/use-cases/planes-estrategicos/03 Objetivos Estrategicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/03 Objetivos Estrategicos.md
@@ -76,7 +76,8 @@ Cada **objetivo estratégico** está vinculado obligatoriamente a un **plan estr
 
 **Flujo principal:**
 1. El usuario abre el submenú "Objetivos estratégicos".
-2. El sistema muestra:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra:
    - Plan estratégico asociado.
    - Código del objetivo.
    - Título y descripción.
@@ -135,11 +136,15 @@ Cada **objetivo estratégico** está vinculado obligatoriamente a un **plan estr
 ---
 
 ## Caso de Uso 8: Listar Evidencias
-**Actores principales:** Usuario.  
+**Actores principales:** Usuario.
+
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
 
 **Flujo principal:**
 1. El usuario selecciona un objetivo.
-2. El sistema muestra la lista de evidencias asociadas:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra la lista de evidencias asociadas:
    - Código de evidencia.
    - Descripción.
 

--- a/docs/funcional/use-cases/planes-estrategicos/05 DAFO Planes Estratégicos.md
+++ b/docs/funcional/use-cases/planes-estrategicos/05 DAFO Planes Estratégicos.md
@@ -68,15 +68,19 @@ La aplicación permite gestionar registros **DAFO** asociados a un **plan estrat
 ## Caso de Uso 4: Listar Registros DAFO
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el submenú "DAFO".
-2. El sistema muestra para cada registro:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada registro:
    - Plan Estratégico.
    - Tipo (códigos **D**, **A**, **F**, **O** con *tooltip* "Debilidad", "Amenaza", "Fortaleza" u "Oportunidad").
    - Título.
    - Descripción.
-3. El usuario dispone de los siguientes controles en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.
-4. El usuario puede:
+4. El usuario dispone de los siguientes controles en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.
+5. El usuario puede:
    - Alternar entre vista tabla y cards.
    - Ordenar ascendente o descendentemente por cualquier columna.
    - Mostrar u ocultar la sección de filtros mediante un botón solo con icono. La sección incluye:

--- a/docs/funcional/use-cases/pmtde-activo/01 PMTDE activo.md
+++ b/docs/funcional/use-cases/pmtde-activo/01 PMTDE activo.md
@@ -1,0 +1,57 @@
+---
+title: "Casos de Uso - PMTDE activo"
+domain: "PMTDE"
+version: "1.0"
+date: "2025-08-22"
+author: "DGSIC"
+---
+
+# Casos de Uso: PMTDE activo
+
+## Contexto
+Los usuarios pueden elegir un PMTDE activo con el que trabajar. El nombre del PMTDE activo aparece en la cabecera de la aplicación junto a la rueda de administración. Si no hay ninguno seleccionado se muestra el texto "Seleccionar PMTDE". La selección determina los registros que se muestran en la mayoría de las pantallas del sistema.
+
+---
+
+## Caso de Uso 1: Seleccionar PMTDE activo
+**Actores principales:** Usuario.
+
+**Precondiciones:**
+- Existen PMTDE registrados.
+
+**Flujo principal:**
+1. En la cabecera, el usuario pulsa sobre el nombre del PMTDE activo o sobre "Seleccionar PMTDE".
+2. El sistema muestra un popup con la lista de PMTDE disponibles.
+3. El usuario elige uno de los PMTDE.
+4. El sistema establece dicho PMTDE como activo y lo muestra subrayado y clicable en la cabecera.
+5. El sistema cierra el popup.
+
+**Postcondiciones:**
+- El PMTDE seleccionado queda como activo y visible en la cabecera.
+
+**Reglas de negocio:**
+- Si no existe un PMTDE activo, el texto mostrado es "Seleccionar PMTDE".
+- El PMTDE activo puede cambiarse en cualquier momento repitiendo el flujo.
+
+---
+
+## Caso de Uso 2: Filtrar registros por PMTDE activo
+**Actores principales:** Usuario.
+
+**Precondiciones:**
+- Hay un PMTDE activo seleccionado.
+
+**Flujo principal:**
+1. El usuario accede a cualquier listado de gestión de entidades.
+2. El sistema aplica automáticamente un filtrado por el PMTDE activo y muestra solo los registros asociados.
+3. El filtrado no puede desactivarse desde los filtros propios del listado.
+4. Al cambiar el PMTDE activo, el sistema actualiza los listados para reflejar la nueva selección.
+
+**Postcondiciones:**
+- Los listados muestran únicamente registros del PMTDE activo.
+
+**Reglas de negocio:**
+- La pantalla de gestión del submenú PMTDE es la única que no aplica este filtrado.
+- El filtrado es fuerte y solo se modifica al cambiar el PMTDE activo.
+
+---

--- a/docs/funcional/use-cases/programas-guardarrailes/01 Programas guardarrailes.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/01 Programas guardarrailes.md
@@ -84,14 +84,18 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 ## Caso de Uso 4: Listar Programas Guardarrail
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el menú "Programas guardarrail" y selecciona el submenú "Programas".
-2. El sistema muestra para cada programa:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada programa:
    - PMTDE asociado.
    - Código.
    - Nombre y descripción.
    - Responsable y grupo de expertos.
-3. El usuario puede:
+4. El usuario puede:
    - Cambiar entre vista tabla o cards.
    - Ordenar por cualquier columna.
    - Abrir la sección de filtros para buscar texto, filtrar por PMTDE, responsable o expertos y reiniciar filtros.

--- a/docs/funcional/use-cases/programas-guardarrailes/02 Principios guardarrailes.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/02 Principios guardarrailes.md
@@ -77,14 +77,18 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 ## Caso de Uso 4: Listar Principios Específicos
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el menú "Programas guardarrail" y selecciona el submenú "Principios guardarrail".
-2. El sistema muestra para cada principio:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada principio:
    - Código.
    - Programa Guardarrail.
    - Título y descripción.
-3. El usuario dispone de un conjunto común de acciones en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.
-4. El usuario puede:
+4. El usuario dispone de un conjunto común de acciones en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.
+5. El usuario puede:
    - Alternar entre vista tabla y cards.
    - Ordenar ascendente o descendentemente por cualquier columna.
    - Mostrar u ocultar una sección de filtros mediante un botón solo con icono. La sección incluye:

--- a/docs/funcional/use-cases/programas-guardarrailes/03 Objetivos Guardarrail.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/03 Objetivos Guardarrail.md
@@ -78,16 +78,20 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 ## Caso de Uso 4: Listar Objetivos Guardarrail
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el submenú "Objetivos guardarrail".
-2. El sistema muestra para cada objetivo:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada objetivo:
    - Programa Guardarrail.
    - Código.
    - Título y descripción.
    - Número de evidencias.
    - Planes estratégicos en los que impacta (se muestra el código; al situar el ratón sobre él se despliega un tooltip con el nombre largo).
-3. El usuario dispone de los siguientes controles en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.
-4. El usuario puede:
+4. El usuario dispone de los siguientes controles en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.
+5. El usuario puede:
    - Alternar entre vista tabla y cards.
    - Ordenar ascendente o descendentemente por cualquier columna.
    - Mostrar u ocultar la sección de filtros mediante un botón solo con icono. La sección incluye:
@@ -155,11 +159,15 @@ Todas las pantallas relacionadas muestran en la parte superior un título con el
 ## Caso de Uso 8: Listar Evidencias
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario selecciona un objetivo guardarrail.
-2. El sistema muestra la lista de evidencias con su código y descripción.
-3. El usuario dispone de los controles comunes: crear, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y a PDF.
-4. El usuario puede:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra la lista de evidencias con su código y descripción.
+4. El usuario dispone de los controles comunes: crear, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y a PDF.
+5. El usuario puede:
    - Alternar entre vista tabla y cards.
    - Ordenar por cualquier columna.
    - Mostrar u ocultar la sección de filtros mediante un botón solo con icono. La sección incluye búsqueda textual en todas las columnas y un botón para limpiar filtros.

--- a/docs/funcional/use-cases/programas-guardarrailes/05 DAFO Programas Guardarrail.md
+++ b/docs/funcional/use-cases/programas-guardarrailes/05 DAFO Programas Guardarrail.md
@@ -68,15 +68,19 @@ La aplicación permite gestionar registros **DAFO** (Debilidades, Amenazas, Fort
 ## Caso de Uso 4: Listar Registros DAFO
 **Actores principales:** Usuario.
 
+**Precondiciones:**
+- Se ha seleccionado un PMTDE activo.
+
 **Flujo principal:**
 1. El usuario abre el submenú "DAFO".
-2. El sistema muestra para cada registro:
+2. El sistema aplica el filtrado por el PMTDE activo.
+3. El sistema muestra para cada registro:
    - Programa Guardarrail.
    - Tipo (códigos **D**, **A**, **F**, **O** con *tooltip* "Debilidad", "Amenaza", "Fortaleza" u "Oportunidad").
    - Título.
    - Descripción.
-3. El usuario dispone de los siguientes controles en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.
-4. El usuario puede:
+4. El usuario dispone de los siguientes controles en este orden: crear nuevo, filtrar, seleccionar columnas, alternar vista tabla/cards, exportar a CSV y exportar a PDF.
+5. El usuario puede:
    - Alternar entre vista tabla y cards.
    - Ordenar ascendente o descendentemente por cualquier columna.
    - Mostrar u ocultar la sección de filtros mediante un botón solo con icono. La sección incluye:


### PR DESCRIPTION
## Summary
- añade documentación de casos de uso para seleccionar el PMTDE activo
- actualiza listados existentes para reflejar el filtrado obligatorio por PMTDE activo
- aclara que la gestión de PMTDE no se filtra por selección activa

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7bc2423c483319863a1fba95812a5