### PR TITLE
Reordena selector de PMTDE en cabecera

### DIFF
--- a/docs/funcional/use-cases/pmtde-activo/01 PMTDE activo.md
+++ b/docs/funcional/use-cases/pmtde-activo/01 PMTDE activo.md
@@ -9,7 +9,7 @@ author: "DGSIC"
 # Casos de Uso: PMTDE activo
 
 ## Contexto
-Los usuarios pueden elegir un PMTDE activo con el que trabajar. El nombre del PMTDE activo aparece en la cabecera de la aplicación junto a la rueda de administración. Si no hay ninguno seleccionado se muestra el texto "Seleccionar PMTDE". La selección determina los registros que se muestran en la mayoría de las pantallas del sistema.
+Los usuarios pueden elegir un PMTDE activo con el que trabajar. El nombre del PMTDE activo aparece en la cabecera de la aplicación antes de la rueda de administración y del menú de perfil. Si no hay ninguno seleccionado se muestra el texto "Seleccionar PMTDE". La selección determina los registros que se muestran en la mayoría de las pantallas del sistema.
 
 ---
 

--- a/frontend/js/App.js
+++ b/frontend/js/App.js
@@ -145,17 +145,17 @@ function App() {
           <Typography variant="h6" sx={{ flexGrow: 1 }}>
             {appName}
           </Typography>
-          <Tooltip title="Administración">
-            <IconButton color="inherit" onClick={() => setView('admin')}>
-              <span className="material-symbols-outlined">settings</span>
-            </IconButton>
-          </Tooltip>
           <Typography
             sx={{ mx: 2, textDecoration: 'underline', cursor: 'pointer' }}
             onClick={() => setSelectPmtdeOpen(true)}
           >
             {activePmtde ? activePmtde.nombre : 'Seleccionar PMTDE'}
           </Typography>
+          <Tooltip title="Administración">
+            <IconButton color="inherit" onClick={() => setView('admin')}>
+              <span className="material-symbols-outlined">settings</span>
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Perfil de usuario">
             <IconButton
               color="inherit"


### PR DESCRIPTION
## Summary
- Sitúa el selector de PMTDE activo antes del menú de administración y del avatar en la barra superior
- Actualiza la documentación de casos de uso para reflejar el nuevo orden en la cabecera

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a84677503c8331942e2c70687be937