### PR TITLE
feat(ui): display codes alongside names

### DIFF
--- a/frontend/js/InputsManager.js
+++ b/frontend/js/InputsManager.js
@@ -1,14 +1,14 @@
 function InputsManager({ inputs, setInputs, pmtde, normativas }) {
-  const columnsConfig = [
-    { key: 'codigo', label: 'Código', render: (i) => i.codigo },
-    { key: 'titulo', label: 'Título', render: (i) => i.titulo },
+    const columnsConfig = [
+      { key: 'codigo', label: 'Código', render: (i) => i.codigo },
+      { key: 'titulo', label: 'Título', render: (i) => displayName(i) },
     {
       key: 'normativa',
       label: 'Normativa',
-      render: (i) =>
-        i.normativa
-          ? `${i.normativa.nombre} (${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`
-          : '',
+        render: (i) =>
+          i.normativa
+            ? `${displayName(i.normativa)} (${i.normativa.organizacion ? displayName(i.normativa.organizacion) : ''})`
+            : '',
     },
     {
       key: 'descripcion',
@@ -59,9 +59,9 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
 
   const filtered = inputs
     .filter((i) => {
-      const normText = i.normativa
-        ? `${i.normativa.nombre} ${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''}`
-        : '';
+        const normText = i.normativa
+          ? `${displayName(i.normativa)} ${i.normativa.organizacion ? displayName(i.normativa.organizacion) : ''}`
+          : '';
       const txt = normalize(`${i.codigo} ${i.titulo} ${normText} ${i.descripcion || ''}`);
       const searchMatch = txt.includes(normalize(search));
       const normMatch = normFilter.length
@@ -86,15 +86,15 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
     });
 
   const exportCSV = () => {
-    const header = ['Código', 'Título', 'Normativa', 'Descripción'];
-    const rows = filtered.map((i) => [
-      i.codigo,
-      i.titulo,
-      i.normativa
-        ? `${i.normativa.nombre} (${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`
-        : '',
-      i.descripcion,
-    ]);
+      const header = ['Código', 'Título', 'Normativa', 'Descripción'];
+      const rows = filtered.map((i) => [
+        i.codigo,
+        displayName(i),
+        i.normativa
+          ? `${displayName(i.normativa)} (${i.normativa.organizacion ? displayName(i.normativa.organizacion) : ''})`
+          : '',
+        i.descripcion,
+      ]);
     exportToCSV(header, rows, 'Inputs');
   };
 
@@ -104,11 +104,11 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
     doc.text('Inputs', 10, 10);
     let y = 20;
     filtered.forEach((i) => {
-      doc.text(
-        `${i.codigo} - ${i.titulo} - ${i.normativa ? i.normativa.nombre : ''} (${i.normativa && i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`,
-        10,
-        y
-      );
+        doc.text(
+          `${displayName(i)} - ${i.normativa ? displayName(i.normativa) : ''} (${i.normativa && i.normativa.organizacion ? displayName(i.normativa.organizacion) : ''})`,
+          10,
+          y
+        );
       y += 10;
       doc.text(i.descripcion || '', 10, y);
       y += 10;
@@ -155,7 +155,7 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
           <Autocomplete
             multiple
             options={normativas}
-            getOptionLabel={(n) => `${n.nombre} (${n.organizacion ? n.organizacion.nombre : ''})`}
+            getOptionLabel={(n) => `${displayName(n)} (${n.organizacion ? displayName(n.organizacion) : ''})`}
             value={normFilter}
             onChange={(e, val) => setNormFilter(val)}
             renderInput={(params) => <TextField {...params} label="Normativa" />}
@@ -209,11 +209,10 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
           {filtered.map((i) => (
             <Card key={i.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{i.codigo}</Typography>
-                <Typography variant="body2">{i.titulo}</Typography>
+                <Typography variant="h6">{displayName(i)}</Typography>
                 <Typography variant="body2">
                   {i.normativa
-                    ? `${i.normativa.nombre} (${i.normativa.organizacion ? i.normativa.organizacion.nombre : ''})`
+                    ? `${displayName(i.normativa)} (${i.normativa.organizacion ? displayName(i.normativa.organizacion) : ''})`
                     : ''}
                 </Typography>
                 <Typography variant="body2" component="div">
@@ -243,14 +242,14 @@ function InputsManager({ inputs, setInputs, pmtde, normativas }) {
           <TextField label="Código" value={current.codigo} disabled />
           <Autocomplete
             options={pmtde}
-            getOptionLabel={(p) => p.nombre}
+            getOptionLabel={(p) => displayName(p)}
             value={current.pmtde}
             onChange={(e, val) => setCurrent({ ...current, pmtde: val, normativa: null })}
             renderInput={(params) => <TextField {...params} label="PMTDE*" />}
           />
           <Autocomplete
             options={normativaOptions}
-            getOptionLabel={(n) => `${n.nombre} (${n.organizacion ? n.organizacion.nombre : ''})`}
+            getOptionLabel={(n) => `${displayName(n)} (${n.organizacion ? displayName(n.organizacion) : ''})`}
             value={current.normativa}
             onChange={(e, val) => setCurrent({ ...current, normativa: val })}
             renderInput={(params) => <TextField {...params} label="Normativa*" />}

--- a/frontend/js/NormativasManager.js
+++ b/frontend/js/NormativasManager.js
@@ -1,15 +1,15 @@
 function NormativasManager({ normativas, setNormativas, pmtde, organizaciones }) {
-  const columnsConfig = [
-    { key: 'codigo', label: 'Código', render: (n) => n.codigo },
-    { key: 'nombre', label: 'Nombre', render: (n) => n.nombre },
-    { key: 'tipo', label: 'Tipo', render: (n) => n.tipo },
-    {
-      key: 'organizacion',
-      label: 'Organización',
-      render: (n) => (n.organizacion ? n.organizacion.nombre : ''),
-    },
-    { key: 'url', label: 'URL', render: (n) => n.url },
-  ];
+    const columnsConfig = [
+      { key: 'codigo', label: 'Código', render: (n) => n.codigo },
+      { key: 'nombre', label: 'Nombre', render: (n) => displayName(n) },
+      { key: 'tipo', label: 'Tipo', render: (n) => n.tipo },
+      {
+        key: 'organizacion',
+        label: 'Organización',
+        render: (n) => (n.organizacion ? displayName(n.organizacion) : ''),
+      },
+      { key: 'url', label: 'URL', render: (n) => n.url },
+    ];
   const tipoOptions = ['Normativa', 'Estrategia', 'Plan', 'Programa', 'Otros'];
   const { columns, openSelector, selector } = useColumnPreferences('normativas', columnsConfig);
   const [dialogOpen, setDialogOpen] = React.useState(false);
@@ -53,7 +53,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
 
   const filtered = normativas
     .filter((n) => {
-      const txt = normalize(`${n.codigo} ${n.nombre} ${n.tipo} ${n.organizacion ? n.organizacion.nombre : ''} ${n.url}`);
+        const txt = normalize(`${n.codigo} ${n.nombre} ${n.tipo} ${n.organizacion ? displayName(n.organizacion) : ''} ${n.url}`);
       const searchMatch = txt.includes(normalize(search));
       const orgMatch = orgFilter.length
         ? orgFilter.some((o) => o.id === (n.organizacion && n.organizacion.id))
@@ -76,8 +76,8 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
     });
 
   const exportCSV = () => {
-    const header = ['Código', 'Nombre', 'Tipo', 'Organización', 'URL'];
-    const rows = filtered.map((n) => [n.codigo, n.nombre, n.tipo, n.organizacion ? n.organizacion.nombre : '', n.url]);
+      const header = ['Código', 'Nombre', 'Tipo', 'Organización', 'URL'];
+      const rows = filtered.map((n) => [n.codigo, displayName(n), n.tipo, n.organizacion ? displayName(n.organizacion) : '', n.url]);
     exportToCSV(header, rows, 'Normativas');
   };
 
@@ -86,10 +86,10 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
     const doc = new jsPDF();
     doc.text('Normativas', 10, 10);
     let y = 20;
-    filtered.forEach((n) => {
-      doc.text(`${n.codigo} - ${n.nombre} - ${n.tipo} - ${n.organizacion ? n.organizacion.nombre : ''} - ${n.url}`, 10, y);
-      y += 10;
-    });
+      filtered.forEach((n) => {
+        doc.text(`${displayName(n)} - ${n.tipo} - ${n.organizacion ? displayName(n.organizacion) : ''} - ${n.url}`, 10, y);
+        y += 10;
+      });
     doc.save(`${formatDate()} Normativas.pdf`);
   };
 
@@ -133,7 +133,7 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
           <Autocomplete
             multiple
             options={organizaciones}
-            getOptionLabel={(o) => o.nombre}
+            getOptionLabel={(o) => displayName(o)}
             value={orgFilter}
             onChange={(e, val) => setOrgFilter(val)}
             renderInput={(params) => <TextField {...params} label="Organización" />}
@@ -194,10 +194,9 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
           {filtered.map((n) => (
             <Card key={n.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{n.codigo}</Typography>
-                <Typography variant="body2">{n.nombre}</Typography>
+                <Typography variant="h6">{displayName(n)}</Typography>
                 <Typography variant="body2">{n.tipo}</Typography>
-                <Typography variant="body2">{n.organizacion ? n.organizacion.nombre : ''}</Typography>
+                <Typography variant="body2">{n.organizacion ? displayName(n.organizacion) : ''}</Typography>
                 <Typography variant="body2">{n.url}</Typography>
                 <Box sx={{ mt: 1 }}>
                   <Tooltip title="Editar">
@@ -233,20 +232,20 @@ function NormativasManager({ normativas, setNormativas, pmtde, organizaciones })
             value={current.nombre}
             onChange={(e) => setCurrent({ ...current, nombre: e.target.value })}
           />
-          <Autocomplete
-            options={pmtde}
-            getOptionLabel={(p) => p.nombre}
-            value={current.pmtde}
-            onChange={(e, val) => setCurrent({ ...current, pmtde: val, organizacion: null })}
-            renderInput={(params) => <TextField {...params} label="PMTDE*" />}
-          />
-          <Autocomplete
-            options={orgOptions}
-            getOptionLabel={(o) => o.nombre}
-            value={current.organizacion}
-            onChange={(e, val) => setCurrent({ ...current, organizacion: val })}
-            renderInput={(params) => <TextField {...params} label="Organización*" />}
-          />
+            <Autocomplete
+              options={pmtde}
+              getOptionLabel={(p) => displayName(p)}
+              value={current.pmtde}
+              onChange={(e, val) => setCurrent({ ...current, pmtde: val, organizacion: null })}
+              renderInput={(params) => <TextField {...params} label="PMTDE*" />}
+            />
+            <Autocomplete
+              options={orgOptions}
+              getOptionLabel={(o) => displayName(o)}
+              value={current.organizacion}
+              onChange={(e, val) => setCurrent({ ...current, organizacion: val })}
+              renderInput={(params) => <TextField {...params} label="Organización*" />}
+            />
           <Autocomplete
             options={tipoOptions}
             value={current.tipo}

--- a/frontend/js/OrganizacionesManager.js
+++ b/frontend/js/OrganizacionesManager.js
@@ -1,7 +1,7 @@
 function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
   const columnsConfig = [
     { key: 'codigo', label: 'Código', render: (o) => o.codigo },
-    { key: 'nombre', label: 'Nombre', render: (o) => o.nombre },
+    { key: 'nombre', label: 'Nombre', render: (o) => displayName(o) },
     {
       key: 'pmtde',
       label: 'PMTDE',
@@ -68,7 +68,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
 
   const exportCSV = () => {
     const header = ['Código', 'Nombre', 'PMTDE'];
-    const rows = filtered.map((o) => [o.codigo, o.nombre, o.pmtde ? o.pmtde.nombre : '']);
+    const rows = filtered.map((o) => [o.codigo, displayName(o), o.pmtde ? displayName(o.pmtde) : '']);
     exportToCSV(header, rows, 'Organizaciones');
   };
 
@@ -78,7 +78,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
     doc.text('Organizaciones', 10, 10);
     let y = 20;
     filtered.forEach((o) => {
-      doc.text(`${o.codigo} - ${o.nombre} - ${o.pmtde ? o.pmtde.nombre : ''}`, 10, y);
+      doc.text(`${displayName(o)} - ${o.pmtde ? displayName(o.pmtde) : ''}`, 10, y);
       y += 10;
     });
     doc.save(`${formatDate()} Organizaciones.pdf`);
@@ -164,9 +164,8 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
           {filtered.map((o) => (
             <Card key={o.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{o.codigo}</Typography>
-                <Typography variant="body2">{o.nombre}</Typography>
-                <Typography variant="body2">{o.pmtde ? o.pmtde.nombre : ''}</Typography>
+                <Typography variant="h6">{displayName(o)}</Typography>
+                <Typography variant="body2">{o.pmtde ? displayName(o.pmtde) : ''}</Typography>
                 <Box sx={{ mt: 1 }}>
                   <Tooltip title="Editar">
                     <IconButton onClick={() => openEdit(o)} disabled={busy}>
@@ -203,7 +202,7 @@ function OrganizacionesManager({ organizaciones, setOrganizaciones, pmtde }) {
           />
           <Autocomplete
             options={pmtde}
-            getOptionLabel={(p) => p.nombre}
+            getOptionLabel={(p) => displayName(p)}
             value={current.pmtde}
             onChange={(e, val) => setCurrent({ ...current, pmtde: val })}
             renderInput={(params) => <TextField {...params} label="PMTDE*" />}

--- a/frontend/js/PlanesEstrategicosManager.js
+++ b/frontend/js/PlanesEstrategicosManager.js
@@ -7,10 +7,10 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
     responsable: null,
     expertos: [],
   };
-  const columnsConfig = [
-    { key: 'codigo', label: 'Código', render: (p) => p.codigo },
-    { key: 'pmtde', label: 'PMTDE', render: (p) => (p.pmtde ? p.pmtde.nombre : '') },
-    { key: 'nombre', label: 'Nombre', render: (p) => p.nombre },
+    const columnsConfig = [
+      { key: 'codigo', label: 'Código', render: (p) => p.codigo },
+      { key: 'pmtde', label: 'PMTDE', render: (p) => (p.pmtde ? displayName(p.pmtde) : '') },
+      { key: 'nombre', label: 'Nombre', render: (p) => displayName(p) },
     {
       key: 'descripcion',
       label: 'Descripción',
@@ -82,11 +82,11 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
 
   const filtered = planesEstrategicos
     .filter((p) => {
-      const txt = normalize(
-        `${p.codigo} ${p.nombre} ${p.descripcion || ''} ${p.pmtde ? p.pmtde.nombre : ''} ${
-          p.responsable ? p.responsable.nombre + ' ' + p.responsable.apellidos : ''
-        } ${p.expertos.map((e) => e.nombre + ' ' + e.apellidos).join(' ')}`
-      );
+        const txt = normalize(
+          `${p.codigo} ${p.nombre} ${p.descripcion || ''} ${p.pmtde ? displayName(p.pmtde) : ''} ${
+            p.responsable ? p.responsable.nombre + ' ' + p.responsable.apellidos : ''
+          } ${p.expertos.map((e) => e.nombre + ' ' + e.apellidos).join(' ')}`
+        );
       const searchMatch = txt.includes(normalize(search));
       const ownerMatch = ownerFilter.length
         ? ownerFilter.some((o) => o.email === (p.responsable && p.responsable.email))
@@ -118,8 +118,8 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
     const header = ['Código', 'PMTDE', 'Nombre', 'Descripción', 'Responsable', 'Grupo de expertos'];
     const rows = filtered.map((p) => [
       p.codigo,
-      p.pmtde ? p.pmtde.nombre : '',
-      p.nombre,
+      p.pmtde ? displayName(p.pmtde) : '',
+      displayName(p),
       p.descripcion,
       p.responsable ? p.responsable.email : '',
       p.expertos.map((e) => e.email).join('|'),
@@ -134,9 +134,7 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
     let y = 20;
     filtered.forEach((p) => {
       doc.text(
-        `${p.codigo} - ${p.nombre} - ${
-          p.responsable ? p.responsable.email : ''
-        } - ${p.pmtde ? p.pmtde.nombre : ''}`,
+        `${displayName(p)} - ${p.responsable ? p.responsable.email : ''} - ${p.pmtde ? displayName(p.pmtde) : ''}`,
         10,
         y
       );
@@ -256,9 +254,8 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
           {filtered.map((p) => (
             <Card key={p.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{p.nombre}</Typography>
-                <Typography variant="body2">{p.codigo}</Typography>
-                <Typography variant="body2">{p.pmtde ? p.pmtde.nombre : ''}</Typography>
+                <Typography variant="h6">{displayName(p)}</Typography>
+                <Typography variant="body2">{p.pmtde ? displayName(p.pmtde) : ''}</Typography>
                 <Typography variant="body2" component="div">
                   <MarkdownRenderer value={p.descripcion} />
                 </Typography>
@@ -289,13 +286,13 @@ function PlanesEstrategicosManager({ usuarios, pmtde = [] }) {
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar plan estratégico' : 'Nuevo plan estratégico'}</DialogTitle>
       <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-        <Autocomplete
-          options={pmtde}
-          getOptionLabel={(p) => p.nombre}
-          value={current.pmtde}
-          onChange={(e, val) => setCurrent({ ...current, pmtde: val })}
-          renderInput={(params) => <TextField {...params} label="PMTDE*" />}
-        />
+          <Autocomplete
+            options={pmtde}
+            getOptionLabel={(p) => displayName(p)}
+            value={current.pmtde}
+            onChange={(e, val) => setCurrent({ ...current, pmtde: val })}
+            renderInput={(params) => <TextField {...params} label="PMTDE*" />}
+          />
         <TextField
           label="Código*"
           value={current.codigo}

--- a/frontend/js/PrincipioGuardarrailManager.js
+++ b/frontend/js/PrincipioGuardarrailManager.js
@@ -1,14 +1,14 @@
 /* global ProcessingBanner */
 
 function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuardarrail, programasGuardarrail }) {
-  const columnsConfig = [
-    {
-      key: 'programa',
-      label: 'Programa',
-      render: (p) => (p.programa ? p.programa.nombre : ''),
-    },
-    { key: 'codigo', label: 'Código', render: (p) => p.codigo },
-    { key: 'titulo', label: 'Título', render: (p) => p.titulo },
+    const columnsConfig = [
+      {
+        key: 'programa',
+        label: 'Programa',
+        render: (p) => (p.programa ? displayName(p.programa) : ''),
+      },
+      { key: 'codigo', label: 'Código', render: (p) => p.codigo },
+      { key: 'titulo', label: 'Título', render: (p) => displayName(p) },
     {
       key: 'descripcion',
       label: 'Descripción',
@@ -56,9 +56,9 @@ function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuard
 
   const filtered = principiosGuardarrail
     .filter((p) => {
-      const txt = normalize(
-        `${p.programa ? p.programa.nombre : ''} ${p.codigo} ${p.titulo} ${p.descripcion || ''}`
-      );
+        const txt = normalize(
+          `${p.programa ? displayName(p.programa) : ''} ${p.codigo} ${p.titulo} ${p.descripcion || ''}`
+        );
       const searchMatch = txt.includes(normalize(search));
       const progMatch = progFilter.length
         ? progFilter.some((pf) => pf.id === (p.programa && p.programa.id))
@@ -78,13 +78,13 @@ function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuard
     });
 
   const exportCSV = () => {
-    const header = ['Programa', 'Código', 'Título', 'Descripción'];
-    const rows = filtered.map((p) => [
-      p.programa ? p.programa.nombre : '',
-      p.codigo,
-      p.titulo,
-      p.descripcion,
-    ]);
+      const header = ['Programa', 'Código', 'Título', 'Descripción'];
+      const rows = filtered.map((p) => [
+        p.programa ? displayName(p.programa) : '',
+        p.codigo,
+        displayName(p),
+        p.descripcion,
+      ]);
     exportToCSV(header, rows, 'PrincipiosGuardarrail');
   };
 
@@ -94,11 +94,11 @@ function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuard
     doc.text('Principios Guardarrail', 10, 10);
     let y = 20;
     filtered.forEach((p) => {
-      doc.text(
-        `${p.codigo} - ${p.titulo} - ${p.programa ? p.programa.nombre : ''}`,
-        10,
-        y
-      );
+        doc.text(
+          `${displayName(p)} - ${p.programa ? displayName(p.programa) : ''}`,
+          10,
+          y
+        );
       y += 10;
       if (y > 280) {
         doc.addPage();
@@ -132,15 +132,15 @@ function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuard
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
-          <Autocomplete
-            multiple
-            options={programasGuardarrail}
-            getOptionLabel={(p) => p.nombre}
-            value={progFilter}
-            onChange={(e, val) => setProgFilter(val)}
-            renderInput={(params) => <TextField {...params} label="Programa" />}
-            sx={{ minWidth: 200 }}
-          />
+            <Autocomplete
+              multiple
+              options={programasGuardarrail}
+              getOptionLabel={(p) => displayName(p)}
+              value={progFilter}
+              onChange={(e, val) => setProgFilter(val)}
+              renderInput={(params) => <TextField {...params} label="Programa" />}
+              sx={{ minWidth: 200 }}
+            />
           <Button onClick={() => { setSearch(''); setProgFilter([]); }}>Reset</Button>
         </Box>
       )}
@@ -194,8 +194,8 @@ function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuard
           {filtered.map((p) => (
             <Card key={p.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{p.codigo} - {p.titulo}</Typography>
-                <Typography variant="body2">{p.programa ? p.programa.nombre : ''}</Typography>
+                  <Typography variant="h6">{displayName(p)}</Typography>
+                  <Typography variant="body2">{p.programa ? displayName(p.programa) : ''}</Typography>
                 <Typography variant="body2" component="div">
                   <MarkdownRenderer value={p.descripcion} />
                 </Typography>
@@ -224,13 +224,13 @@ function PrincipioGuardarrailManager({ principiosGuardarrail, setPrincipiosGuard
       >
         <DialogTitle>{current.id ? 'Editar principio guardarrail' : 'Nuevo principio guardarrail'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-          <Autocomplete
-            options={programasGuardarrail}
-            getOptionLabel={(p) => p.nombre}
-            value={current.programa}
-            onChange={(e, val) => setCurrent({ ...current, programa: val })}
-            renderInput={(params) => <TextField {...params} label="Programa*" />}
-          />
+            <Autocomplete
+              options={programasGuardarrail}
+              getOptionLabel={(p) => displayName(p)}
+              value={current.programa}
+              onChange={(e, val) => setCurrent({ ...current, programa: val })}
+              renderInput={(params) => <TextField {...params} label="Programa*" />}
+            />
           <TextField label="Código" value={current.codigo} disabled />
           <TextField
             label="Título*"

--- a/frontend/js/PrincipiosEspecificosManager.js
+++ b/frontend/js/PrincipiosEspecificosManager.js
@@ -1,9 +1,9 @@
 function PrincipiosEspecificosManager() {
   const empty = { plan: null, codigo: '', titulo: '', descripcion: '' };
-  const columnsConfig = [
-    { key: 'codigo', label: 'Código', render: (p) => p.codigo },
-    { key: 'plan', label: 'Plan estratégico', render: (p) => (p.plan ? p.plan.nombre : '') },
-    { key: 'titulo', label: 'Título', render: (p) => p.titulo },
+    const columnsConfig = [
+      { key: 'codigo', label: 'Código', render: (p) => p.codigo },
+      { key: 'plan', label: 'Plan estratégico', render: (p) => (p.plan ? displayName(p.plan) : '') },
+      { key: 'titulo', label: 'Título', render: (p) => displayName(p) },
     {
       key: 'descripcion',
       label: 'Descripción',
@@ -58,9 +58,9 @@ function PrincipiosEspecificosManager() {
 
   const filtered = principios
     .filter((p) => {
-      const txt = normalize(
-        `${p.codigo} ${p.titulo} ${p.descripcion || ''} ${p.plan ? p.plan.nombre : ''}`
-      );
+        const txt = normalize(
+          `${p.codigo} ${p.titulo} ${p.descripcion || ''} ${p.plan ? displayName(p.plan) : ''}`
+        );
       const searchMatch = txt.includes(normalize(search));
       const planMatch = planFilter.length
         ? planFilter.some((pf) => p.plan && pf.id === p.plan.id)
@@ -80,13 +80,13 @@ function PrincipiosEspecificosManager() {
     });
 
   const exportCSV = () => {
-    const header = ['Código', 'Plan', 'Título', 'Descripción'];
-    const rows = filtered.map((p) => [
-      p.codigo,
-      p.plan ? p.plan.nombre : '',
-      p.titulo,
-      p.descripcion,
-    ]);
+      const header = ['Código', 'Plan', 'Título', 'Descripción'];
+      const rows = filtered.map((p) => [
+        p.codigo,
+        p.plan ? displayName(p.plan) : '',
+        displayName(p),
+        p.descripcion,
+      ]);
     exportToCSV(header, rows, 'principios_especificos');
   };
 
@@ -96,11 +96,11 @@ function PrincipiosEspecificosManager() {
     doc.text('Principios específicos', 10, 10);
     let y = 20;
     filtered.forEach((p) => {
-      doc.text(
-        `${p.codigo} - ${p.titulo} - ${p.plan ? p.plan.nombre : ''}`,
-        10,
-        y
-      );
+        doc.text(
+          `${displayName(p)} - ${p.plan ? displayName(p.plan) : ''}`,
+          10,
+          y
+        );
       y += 10;
     });
     doc.save(`${formatDate()} PrincipiosEspecificos.pdf`);
@@ -136,14 +136,14 @@ function PrincipiosEspecificosManager() {
       {filterOpen && (
         <Box sx={{ mb: 2, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
           <TextField label="Buscar" value={search} onChange={(e) => setSearch(e.target.value)} />
-          <Autocomplete
-            multiple
-            options={planes}
-            getOptionLabel={(p) => p.nombre}
-            value={planFilter}
-            onChange={(e, val) => setPlanFilter(val)}
-            renderInput={(params) => <TextField {...params} label="Plan" />}
-          />
+            <Autocomplete
+              multiple
+              options={planes}
+              getOptionLabel={(p) => displayName(p)}
+              value={planFilter}
+              onChange={(e, val) => setPlanFilter(val)}
+              renderInput={(params) => <TextField {...params} label="Plan" />}
+            />
           <Button onClick={resetFilters}>Reset</Button>
         </Box>
       )}
@@ -192,9 +192,8 @@ function PrincipiosEspecificosManager() {
           {filtered.map((p) => (
             <Card key={p.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{p.titulo}</Typography>
-                <Typography variant="body2">{p.codigo}</Typography>
-                <Typography variant="body2">{p.plan ? p.plan.nombre : ''}</Typography>
+                <Typography variant="h6">{displayName(p)}</Typography>
+                <Typography variant="body2">{p.plan ? displayName(p.plan) : ''}</Typography>
                 <Typography variant="body2" component="div">
                   <MarkdownRenderer value={p.descripcion} />
                 </Typography>
@@ -219,13 +218,13 @@ function PrincipiosEspecificosManager() {
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} PaperProps={{ sx: { minWidth: '50vw' } }}>
         <DialogTitle>{current.id ? 'Editar principio específico' : 'Nuevo principio específico'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-          <Autocomplete
-            options={planes}
-            getOptionLabel={(p) => p.nombre}
-            value={current.plan}
-            onChange={(e, val) => setCurrent({ ...current, plan: val })}
-            renderInput={(params) => <TextField {...params} label="Plan estratégico*" />}
-          />
+            <Autocomplete
+              options={planes}
+              getOptionLabel={(p) => displayName(p)}
+              value={current.plan}
+              onChange={(e, val) => setCurrent({ ...current, plan: val })}
+              renderInput={(params) => <TextField {...params} label="Plan estratégico*" />}
+            />
           <TextField label="Código" value={current.codigo} disabled />
           <TextField
             label="Título*"

--- a/frontend/js/ProgramaGuardarrailManager.js
+++ b/frontend/js/ProgramaGuardarrailManager.js
@@ -1,8 +1,8 @@
 function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarrail, pmtde, usuarios, refreshPrincipios }) {
-  const columnsConfig = [
-    { key: 'pmtde', label: 'PMTDE', render: (p) => (p.pmtde ? p.pmtde.nombre : '') },
-    { key: 'codigo', label: 'Código', render: (p) => p.codigo },
-    { key: 'nombre', label: 'Nombre', render: (p) => p.nombre },
+    const columnsConfig = [
+      { key: 'pmtde', label: 'PMTDE', render: (p) => (p.pmtde ? displayName(p.pmtde) : '') },
+      { key: 'codigo', label: 'Código', render: (p) => p.codigo },
+      { key: 'nombre', label: 'Nombre', render: (p) => displayName(p) },
     {
       key: 'descripcion',
       label: 'Descripción',
@@ -71,11 +71,11 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
 
   const filtered = programasGuardarrail
     .filter((p) => {
-      const txt = normalize(
-        `${p.pmtde ? p.pmtde.nombre : ''} ${p.codigo} ${p.nombre} ${p.descripcion || ''} ${
-          p.responsable ? p.responsable.nombre + ' ' + p.responsable.apellidos : ''
-        } ${p.expertos.map((e) => e.nombre + ' ' + e.apellidos).join(' ')}`
-      );
+        const txt = normalize(
+          `${p.pmtde ? displayName(p.pmtde) : ''} ${p.codigo} ${p.nombre} ${p.descripcion || ''} ${
+            p.responsable ? p.responsable.nombre + ' ' + p.responsable.apellidos : ''
+          } ${p.expertos.map((e) => e.nombre + ' ' + e.apellidos).join(' ')}`
+        );
       const searchMatch = txt.includes(normalize(search));
       const respMatch = respFilter.length
         ? respFilter.some((rf) => rf.email === (p.responsable && p.responsable.email))
@@ -102,29 +102,29 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
     });
 
   const exportCSV = () => {
-    const header = ['PMTDE', 'Código', 'Nombre', 'Descripción', 'Responsable', 'Grupo de expertos'];
-    const rows = filtered.map((p) => [
-      p.pmtde ? p.pmtde.nombre : '',
-      p.codigo,
-      p.nombre,
-      p.descripcion,
-      p.responsable ? p.responsable.email : '',
-      p.expertos.map((e) => e.email).join(',')
-    ]);
+      const header = ['PMTDE', 'Código', 'Nombre', 'Descripción', 'Responsable', 'Grupo de expertos'];
+      const rows = filtered.map((p) => [
+        p.pmtde ? displayName(p.pmtde) : '',
+        p.codigo,
+        displayName(p),
+        p.descripcion,
+        p.responsable ? p.responsable.email : '',
+        p.expertos.map((e) => e.email).join(',')
+      ]);
     exportToCSV(header, rows, 'ProgramasGuardarrail');
   };
 
   const exportPDF = () => {
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
-    doc.text('Programas Guardarrail', 10, 10);
+      doc.text('Programas Guardarrail', 10, 10);
     let y = 20;
     filtered.forEach((p) => {
-      doc.text(
-        `${p.codigo} - ${p.nombre} - ${p.responsable ? p.responsable.email : ''} - ${p.pmtde ? p.pmtde.nombre : ''}`,
-        10,
-        y
-      );
+        doc.text(
+          `${displayName(p)} - ${p.responsable ? p.responsable.email : ''} - ${p.pmtde ? displayName(p.pmtde) : ''}`,
+          10,
+          y
+        );
       y += 10;
     });
     doc.save(`${formatDate()} ProgramasGuardarrail.pdf`);
@@ -240,8 +240,8 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
           {filtered.map((p) => (
             <Card key={p.id} sx={{ width: 250 }}>
               <CardContent>
-                <Typography variant="h6">{p.codigo} - {p.nombre}</Typography>
-                <Typography variant="body2">{p.pmtde ? p.pmtde.nombre : ''}</Typography>
+                <Typography variant="h6">{displayName(p)}</Typography>
+                <Typography variant="body2">{p.pmtde ? displayName(p.pmtde) : ''}</Typography>
                 <Typography variant="body2" component="div">
                   <MarkdownRenderer value={p.descripcion} />
                 </Typography>
@@ -277,8 +277,8 @@ function ProgramaGuardarrailManager({ programasGuardarrail, setProgramasGuardarr
         <DialogTitle>{current.id ? 'Editar programa guardarrail' : 'Nuevo programa guardarrail'}</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
           <Autocomplete
-            options={pmtde}
-            getOptionLabel={(p) => p.nombre}
+              options={pmtde}
+              getOptionLabel={(p) => displayName(p)}
             value={current.pmtde}
             onChange={(e, val) => setCurrent({ ...current, pmtde: val })}
             renderInput={(params) => <TextField {...params} label="PMTDE*" />}

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -68,4 +68,10 @@ const normalize = (s) =>
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '');
 
+const displayName = (o) => {
+  if (!o) return '';
+  const name = o.nombre ?? o.titulo ?? o.descripcion ?? '';
+  return o.codigo ? `${o.codigo} - ${name}` : name;
+};
+
 const tableHeadSx = { backgroundColor: '#f5f5f5', '& th': { fontWeight: 'bold' } };


### PR DESCRIPTION
## Summary
- ensure entities with `codigo` show `codigo - nombre` using new `displayName` helper
- apply combined code-name format across organization, program, principle, input, plan and normativa managers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a85aa0fc7083318dd9596beadf8657