### PR TITLE
fix: avoid infinite reload on unauthorized

### DIFF
--- a/frontend/js/AuthApi.js
+++ b/frontend/js/AuthApi.js
@@ -3,20 +3,33 @@ const originalFetch = window.fetch.bind(window);
 window.fetch = (url, options = {}) => {
   options.headers = options.headers || {};
   if (token) options.headers['Authorization'] = token;
-  return originalFetch(url, options).then((res) => {
-    if (res.status === 401) {
-      token = null;
-      localStorage.removeItem('token');
-      window.location.href = '/';
-    }
-    return res;
-  });
+  return originalFetch(url, options)
+    .then((res) => {
+      if (res.status === 401) {
+        token = null;
+        localStorage.removeItem('token');
+        if (!url.includes('/api/auth/me')) {
+          window.location.href = '/';
+        }
+      }
+      return res;
+    })
+    .catch((err) => {
+      console.error('Fetch error:', err);
+      throw err;
+    });
 };
 
 const authApi = {
   me: async () => {
-    const res = await fetch('/api/auth/me');
-    return res.json();
+    try {
+      const res = await fetch('/api/auth/me');
+      if (res.status === 401) return { user: null, useAuth: true };
+      if (!res.ok) return { user: null, useAuth: false };
+      return res.json();
+    } catch {
+      return { user: null, useAuth: false };
+    }
   },
   login: async (username, password, ssoToken) => {
     const res = await fetch('/api/auth/login', {


### PR DESCRIPTION
## Summary
- prevent redirect loop on auth check when LDAP auth enabled
- handle missing/failed auth gracefully

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a860bb1e78833189f5d648d668c2c7